### PR TITLE
Remove change_logs from front matter across the site

### DIFF
--- a/articles/accessing-and-configuring-your-invoices.mdx
+++ b/articles/accessing-and-configuring-your-invoices.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to access and configure your invoices in CloudCannon."
 tags: ["invoices","Billing","Invoice email","Billing email","Billing address"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-10-10 20:49:19 +0000"}]
 related_articles: ["how-to-pay-for-cloudcannon","how-cloudcannon-handles-failed-payments"]
 related_links: null
 ---

--- a/articles/add-files-with-direct-upload.mdx
+++ b/articles/add-files-with-direct-upload.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/files-source-syncing-file-upload.png"
 description: Need to test a site without source syncing? Learn how to directly upload files your source files.
 tags: ["Syncing"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Split between uploading for a new site and upload from file browser","_created_at":"2021-09-21 23:43:24 +0000"}]
 related_articles: ["creating-backups-of-your-source-files"]
 related_links: null
 ---

--- a/articles/add-project-links-to-make-common-tasks-even-quicker.mdx
+++ b/articles/add-project-links-to-make-common-tasks-even-quicker.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/projects-project-links.png"
 description: "Learn how to add Project Links to your CloudCannon project dashboard. You can use these to navigate to external resources, or often-used parts of the app."
 tags: ["git","projects","configuration"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-26 21:49:00 +0000"}]
 related_articles: ["enabling-editor-branching-with-projects","setting-up-a-publish-branch-with-merging-or-pull-requests"]
 related_links: null
 ---

--- a/articles/adding-i18n-to-your-site-for-global-audiences.mdx
+++ b/articles/adding-i18n-to-your-site-for-global-audiences.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/i18n-enable-i18n.png"
 description: "Make your website more accessible to an international audience."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Reviewed content and updated screenshot","_created_at":"2021-09-29 03:09:21 +0000"}]
 related_articles: ["using-geolocation-to-detect-your-users-country"]
 related_links: null
 ---

--- a/articles/adding-password-authentication-to-your-site.mdx
+++ b/articles/adding-password-authentication-to-your-site.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Require a password to access your site."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/adding-saml-authentication-to-your-site.mdx
+++ b/articles/adding-saml-authentication-to-your-site.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Restrict access to your site by using a third-party login service."
 tags: ["saml","authentication","security"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/adding-user-account-authentication-to-your-site.mdx
+++ b/articles/adding-user-account-authentication-to-your-site.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Restrict access to your site to a set of users you invite."
 tags: ["authentication","security","login","account"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/adjusting-the-uploads-path.mdx
+++ b/articles/adjusting-the-uploads-path.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Uploads paths are locations where new asset files are uploaded to within the editor. They also defines the default location when selecting existing files. There are a number of placeholders available to aid in organization."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-08-18 03:41:00 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/allowing-users-to-logout-from-your-site.mdx
+++ b/articles/allowing-users-to-logout-from-your-site.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Provide a logout button on your authenticated pages."
 tags: ["authentication","security"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/array-structures-reference.mdx
+++ b/articles/array-structures-reference.mdx
@@ -8,9 +8,6 @@ published: true
 image: /documentation/static/CloudCannonDocumentationog.jpg
 description: A list of key options for using Structures.
 tags: []
-change_logs:
-  - name: Initial Version
-    _created_at: '2021-09-15 23:13:40 +0000'
 related_articles:
   - using-arrays-to-edit-your-data
   - using-a-modal-with-array-structures

--- a/articles/caching-specific-folders-to-reduce-build-times.mdx
+++ b/articles/caching-specific-folders-to-reduce-build-times.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to choose specific files and folders to cache between builds with CloudCannon. This can let you bypass install steps, speeding up subsequent builds."
 tags: ["build","performance"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/changing-how-cards-preview-your-data.mdx
+++ b/articles/changing-how-cards-preview-your-data.mdx
@@ -9,11 +9,6 @@ description: >-
   CloudCannon uses configurable cards to represent your data in different places
   across the app
 tags: []
-change_logs:
-  - name: Initial Version
-    _created_at: '2022-11-02 01:04:39 +0000'
-  - name: Add more locations
-    _created_at: '2022-11-17 22:55:12 +0000'
 related_articles:
 related_links:
 ---

--- a/articles/changing-your-ssg-cli-options.mdx
+++ b/articles/changing-your-ssg-cli-options.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Most static site generators offer a number of configuration options for use on the command line. Configure these and other CloudCannon-specific build options per site."
 tags: ["build"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["managing-your-node-version-with-nvm","what-version-of-go-is-used-in-the-build-environment","managing-your-ruby-version","optimizing-your-build-by-minifying-css-and-javascript"]
 related_links: null
 ---

--- a/articles/choosing-the-editors-for-each-file.mdx
+++ b/articles/choosing-the-editors-for-each-file.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Select the preferred editor and additional editors available to your team members for each file."
 tags: ["editors","configuration"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["introducing-the-visual-editor","introducing-the-content-editor","introducing-the-data-editor","introducing-the-source-editor"]
 related_links: null
 ---

--- a/articles/choosing-where-to-create-new-files.mdx
+++ b/articles/choosing-where-to-create-new-files.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/save-confirmation.png"
 description: "When you create a file for a collection in CloudCannon, it is saved at a path generated from a configured pattern.\nThese patterns are called \"Create Paths\". Create Paths are templates with a mixture of literal text and placeholders. You can use this to organize where your content files are stored as your team members create them."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-12-07 01:51:21 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/choosing-which-pages-require-authentication-on-your-site.mdx
+++ b/articles/choosing-which-pages-require-authentication-on-your-site.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Auth routes allow you to specify the routes you want to be authenticated and keep the rest public."
 tags: ["authentication","security"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: ["adding-password-authentication-to-your-site"]
 related_links: null
 ---

--- a/articles/cloudcannon-protocol.mdx
+++ b/articles/cloudcannon-protocol.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "CloudCannon links are a custom protocol that allows you to deep link into CloudCannon."
 tags: ["editor","navigation","collections","front matter"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["introducing-the-visual-editor"]
 related_links: null
 ---

--- a/articles/configuring-custom-routing.mdx
+++ b/articles/configuring-custom-routing.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Configure your CloudCannon's hosting by configuring a single json file."
 tags: ["Hosting","Sites","Redirects","Custom Headers","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: [{"name":"RE2","url":"https://github.com/uhop/node-re2"}]
 ---

--- a/articles/configuring-extensionless-urls.mdx
+++ b/articles/configuring-extensionless-urls.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Extensionless URLs do not end with a trailing slash or a file extension."
 tags: ["Hosting","Sites","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/configuring-toolbars.mdx
+++ b/articles/configuring-toolbars.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "TODO"
 tags: ["editor"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-26 00:00:00 +0000"}]
 related_articles: ["introducing-the-visual-editor"]
 related_links: null
 ---

--- a/articles/configuring-with-placeholders.mdx
+++ b/articles/configuring-with-placeholders.mdx
@@ -7,9 +7,6 @@ published: true
 image: /uploads/CloudCannonDocumentationog.jpg
 description:
 tags: []
-change_logs:
-  - name: Initial Version
-    _created_at: '2023-01-31 02:22:28 +0000'
 related_articles:
 related_links:
 ---

--- a/articles/configuring-your-build.mdx
+++ b/articles/configuring-your-build.mdx
@@ -15,9 +15,6 @@ description: >-
   like to join the beta.
 tags:
   - build
-change_logs:
-  - name: Initial Version
-    _created_at: '2021-09-15 23:13:40 +0000'
 related_articles:
   - extending-your-build-process-with-hooks
 related_links: []

--- a/articles/configuring-your-markdown-engine.mdx
+++ b/articles/configuring-your-markdown-engine.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "To store and edit Markdown content in CloudCannon, we need to process it into HTML to make it editable. CloudCannon supports the CommonMark and Kramdown specifications. The implementations for these are markdown-it (JavaScript) and kramdown (Ruby)."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/connecting-a-bitbucket-respository-as-your-source.mdx
+++ b/articles/connecting-a-bitbucket-respository-as-your-source.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/files-source-syncing-bitbucket-bitbucket-selected.png"
 description: "Learn how to connect a Bitbucket repository to your site with CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Review content and added new screenshots","_created_at":"2021-09-29 01:34:50 +0000"}]
 related_articles: ["creating-backups-of-your-source-files"]
 related_links: null
 ---

--- a/articles/connecting-a-github-enterprise-server-repository-as-your-source.mdx
+++ b/articles/connecting-a-github-enterprise-server-repository-as-your-source.mdx
@@ -10,7 +10,6 @@ description: >-
   Learn how to connect a GitHub Enterprise Server repository as your source with
   CloudCannon.
 tags: []
-change_logs: []
 related_articles:
   - creating-backups-of-your-source-files
   - connecting-a-github-repository-as-your-source

--- a/articles/connecting-a-github-repository-as-your-source.mdx
+++ b/articles/connecting-a-github-repository-as-your-source.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/files-source-syncing-github-github-selected.png"
 description: "Learn how to connect a GitHub repository to your site with CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"New screenshots + updated text","_created_at":"2021-09-22 04:43:05 +0000"}]
 related_articles: ["creating-backups-of-your-source-files"]
 related_links: null
 ---

--- a/articles/connecting-a-gitlab-respository-as-your-source.mdx
+++ b/articles/connecting-a-gitlab-respository-as-your-source.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/files-source-syncing-gitlab-gitlab-selected.png"
 description: "Learn how to connect a GitLab repository to your site with CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Review content and updated screenshots","_created_at":"2021-09-29 01:18:28 +0000"}]
 related_articles: ["connecting-a-self-hosted-gitlab-repository-as-your-source","creating-backups-of-your-source-files"]
 related_links: null
 ---

--- a/articles/connecting-a-self-hosted-gitlab-repository-as-your-source.mdx
+++ b/articles/connecting-a-self-hosted-gitlab-repository-as-your-source.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/self-hosted-gitlab-selected.png"
 description: "Learn how to connect a self-hosted GitLab repository as your source with CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"New screenshots + updated text","_created_at":"2021-09-22 03:40:28 +0000"}]
 related_articles: ["creating-backups-of-your-source-files","connecting-a-gitlab-respository-as-your-source"]
 related_links: null
 ---

--- a/articles/connecting-your-site-to-an-inbox.mdx
+++ b/articles/connecting-your-site-to-an-inbox.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Connect forms on your site to an Inbox."
 tags: ["Hosting","Forms"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:31:04 +0000"}]
 related_articles: ["viewing-your-form-submissions-in-cloudcannon"]
 related_links: null
 ---

--- a/articles/creating-a-cloudinary-dam.mdx
+++ b/articles/creating-a-cloudinary-dam.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: Set up a DAM with Cloudinary and link it to your CloudCannon Organization
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:32:26 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/creating-a-custom-404-page.mdx
+++ b/articles/creating-a-custom-404-page.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Create your own 404 page to blend in with the rest of your site."
 tags: ["Hosting","Sites","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/creating-a-form-for-your-site-on-cloudcannon.mdx
+++ b/articles/creating-a-form-for-your-site-on-cloudcannon.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Create forms on your site and send the submissions to an email address or integrate with your own workflows."
 tags: ["forms","webhooks","hosting"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: ["reducing-spam-by-adding-google-recaptcha"]
 related_links: [{"name":"Zapier","url":"https://zapier.com/"},{"name":"Zapier Documentation","url":"https://zapier.com/help/create/code-webhooks"},{"name":"Automate","url":"https://automate.io/"},{"name":"Automate Documentation","url":"https://docs.automate.io/en/articles/1305409-webhooks"},{"name":"IFTTT","url":"https://ifttt.com/"},{"name":"IFTTT FAQ","url":"https://help.ifttt.com/hc/en-us/articles/115010230347-The-Webhooks-Service"}]
 ---

--- a/articles/creating-a-google-cloud-storage-dam.mdx
+++ b/articles/creating-a-google-cloud-storage-dam.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: Set up a DAM with Google Cloud Storage and link it to your CloudCannon Organization
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-08-17 04:40:51 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/creating-a-new-organization.mdx
+++ b/articles/creating-a-new-organization.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to create a new Organization in CloudCannon."
 tags: ["Organizations"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/creating-a-tenovos-dam.mdx
+++ b/articles/creating-a-tenovos-dam.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Connect Tenovos to CloudCannon and allow editors to choose files from your DAM"
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:33:00 +0000"}]
 related_articles: ["/articles/introduction-to-assets-and-dams","/articles/integrating-your-dam-with-cloudcannon","/articles/managing-dams-on-your-organisaiton"]
 related_links: null
 ---

--- a/articles/creating-an-azure-dam.mdx
+++ b/articles/creating-an-azure-dam.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: Link your Azure DAM to your CloudCannon Organization
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-04-07 05:13:01 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/creating-an-inbox-to-receive-your-forms.mdx
+++ b/articles/creating-an-inbox-to-receive-your-forms.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Create an Inbox to receive your form submissions."
 tags: ["Hosting","Forms"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:30:25 +0000"}]
 related_articles: ["connecting-your-site-to-an-inbox"]
 related_links: null
 ---

--- a/articles/creating-an-s3-dam.mdx
+++ b/articles/creating-an-s3-dam.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: Set up a DAM with S3 and link it to your CloudCannon Organization
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:31:41 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/creating-backups-of-your-source-files.mdx
+++ b/articles/creating-backups-of-your-source-files.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/files-source-syncing-backups.png"
 description: "Generate an archive of your source files. This is used to protect unintentional deletions when changing repositories/branches on a site."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Added screenshot","_created_at":"2021-09-22 02:38:08 +0000"}]
 related_articles: ["connecting-a-github-repository-as-your-source","connecting-a-gitlab-respository-as-your-source","connecting-a-self-hosted-gitlab-repository-as-your-source","connecting-a-bitbucket-respository-as-your-source","add-files-with-direct-upload"]
 related_links: null
 ---

--- a/articles/creating-collection-schemas.mdx
+++ b/articles/creating-collection-schemas.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to create collection schemas for managing content across files in a collection."
 tags: ["editor"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-04-19 03:08:59 +0000"},{"name":"Schemas","_created_at":"2022-04-19 03:08:59 +0000"}]
 related_articles: ["defining-your-collections"]
 related_links: null
 ---

--- a/articles/custom-ssl-certificates-for-your-sites-hosted-on-cloudcannon.mdx
+++ b/articles/custom-ssl-certificates-for-your-sites-hosted-on-cloudcannon.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to add custom PEM-encoded SSL certificates."
 tags: ["hosting","ssl"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/customizing-cloudcannon-to-match-your-brand.mdx
+++ b/articles/customizing-cloudcannon-to-match-your-brand.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to customize CloudCannon to match your brand."
 tags: ["Organizations","branding"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/defining-editable-regions-in-your-html.mdx
+++ b/articles/defining-editable-regions-in-your-html.mdx
@@ -11,13 +11,6 @@ description: >-
   updates.
 tags:
   - editor
-change_logs:
-  - name: Initial Version
-    _created_at: '2021-09-15 05:03:07 +0000'
-  - name: Added image_size_attributes
-    _created_at: '2022-03-14 22:37:34 +0000'
-  - name: Updated paths and availability for each option.
-    _created_at: '2022-08-18 05:04:56 +0000'
 related_articles:
   - introducing-the-visual-editor
 related_links: []

--- a/articles/defining-more-ways-to-add-new-files.mdx
+++ b/articles/defining-more-ways-to-add-new-files.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/editing-collections-add-options.png"
 description: "Learn how to create or change actions for the add menu in the collection file list."
 tags: ["editor","configuration"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Schemas details","_created_at":"2022-04-19 10:16:50 +0000"}]
 related_articles: ["extending-in-app-navigation-with-editor-links"]
 related_links: [{"name":"Material Icons","url":"https://material.io/tools/icons/"}]
 ---

--- a/articles/defining-the-default-contents-of-new-files.mdx
+++ b/articles/defining-the-default-contents-of-new-files.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to provide initial front matter and/or content for new collection files in CloudCannon."
 tags: ["editor"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Schemas","_created_at":"2022-04-18 23:38:43 +0000"}]
 related_articles: ["defining-your-collections"]
 related_links: null
 ---

--- a/articles/defining-what-adds-to-an-array-with-array-structures.mdx
+++ b/articles/defining-what-adds-to-an-array-with-array-structures.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Array add values allow you to define which keys in your data should be arrays, what data should be added when 'Add' is clicked, and how the editor can decide what item to add."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["using-arrays-to-edit-your-data"]
 related_links: null
 ---

--- a/articles/defining-your-collections.mdx
+++ b/articles/defining-your-collections.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Collections allow you to show groups of related content in the Site Navigation. Each collection corresponds to a folder in your site files. Navigating to a collection shows a preview of each file and allows your editors to see all the content at a glance."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Added reader info and a few missing fields","_created_at":"2021-09-23 04:45:49 +0000"}]
 related_articles: ["introducing-your-site-navigation","unlisting-files-in-a-collection","integrating-your-site","defining-more-ways-to-add-new-files"]
 related_links: null
 ---

--- a/articles/defining-your-data.mdx
+++ b/articles/defining-your-data.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Defining data allows you to populate select and multiselect inputs. Each data set corresponds to a file or folder in your site files."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-01-11 15:13:40 +0000"}]
 related_articles: ["introducing-your-site-navigation","unlisting-files-in-a-collection","integrating-your-site","defining-more-ways-to-add-new-files"]
 related_links: null
 ---

--- a/articles/deprecated-301-redirects.mdx
+++ b/articles/deprecated-301-redirects.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "301.txt redirects are deprecated, use routing.json to configure this with more options."
 tags: ["Hosting","Sites","Redirects","Deprecated","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["configuring-custom-routing"]
 related_links: null
 ---

--- a/articles/detecting-your-site-is-loaded-in-the-visual-editor.mdx
+++ b/articles/detecting-your-site-is-loaded-in-the-visual-editor.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "You can define situations where you want to show content to editors when they’re in the Visual Editor, but not show it on the live site."
 tags: ["visual editor","editors"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/disabling-authentication-on-your-site.mdx
+++ b/articles/disabling-authentication-on-your-site.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "How to turn off authentication for your CloudCannon site. "
 tags: ["authentication","security"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/disabling-editor-publishing.mdx
+++ b/articles/disabling-editor-publishing.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to disable editor publishing with CloudCannon."
 tags: ["publishing","git"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/editing-markdown-files-in-the-visual-editor.mdx
+++ b/articles/editing-markdown-files-in-the-visual-editor.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to edit your markdown files as they would appear on your live site, with CloudCannon."
 tags: ["markdown","visual editor","editing"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: ["introducing-the-visual-editor"]
 related_links: null
 ---

--- a/articles/editing-objects-in-your-data.mdx
+++ b/articles/editing-objects-in-your-data.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Object inputs in your data show as a button in the data editor. This button opens a new editor to the side, showing the inputs inside that object. This continues as you click into nested Object inputs. Each object level has a back button to return to the parent scope."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"},{"name":"Input configuration","_created_at":"2021-11-08 00:02:30 +0000"},{"name":"Add preview option","_created_at":"2022-11-16 03:52:59 +0000"}]
 related_articles: ["how-to-choose-what-input-is-used-in-the-data-editor","using-the-configuration-cascade","array-structures-reference","defining-what-adds-to-an-array-with-array-structures"]
 related_links: [{"name":"Material Icons","url":"https://material.io/tools/icons/"}]
 ---

--- a/articles/editing-with-eleventy-shortcodes.mdx
+++ b/articles/editing-with-eleventy-shortcodes.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to add and edit Snippets in the content of your Eleventy website via CloudCannon."
 tags: ["content editor","snippets","eleventy"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-11-21 02:00:59 +0000"}]
 related_articles: ["/articles/introducing-the-content-editor"]
 related_links: null
 ---

--- a/articles/editing-with-hugo-shortcodes.mdx
+++ b/articles/editing-with-hugo-shortcodes.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to add and edit shortcodes in the content of your Hugo website via CloudCannon."
 tags: ["content editor","snippets","hugo"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-10-27 02:00:59 +0000"}]
 related_articles: ["/articles/introducing-the-content-editor"]
 related_links: null
 ---

--- a/articles/editing-with-mdx-components.mdx
+++ b/articles/editing-with-mdx-components.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to add and edit components in the content of your MDX website via CloudCannon."
 tags: ["content editor","snippets","MDX"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-10-27 02:00:59 +0000"}]
 related_articles: ["/articles/introducing-the-content-editor"]
 related_links: null
 ---

--- a/articles/editor-merging-and-pull-requests-with-publishing.mdx
+++ b/articles/editor-merging-and-pull-requests-with-publishing.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to merge and create and review pull requests with publishing workflows on CloudCannon."
 tags: ["git","publish","branch"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["setting-up-a-publish-branch-with-merging-or-pull-requests","enabling-editor-branching-with-projects"]
 related_links: null
 ---

--- a/articles/enabling-editor-branching-with-projects.mdx
+++ b/articles/enabling-editor-branching-with-projects.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/projects-project-with-sites.png"
 description: "Learn how to group multiple sites from the same repository together with CloudCannon."
 tags: ["Projects","Git","Branching"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["add-project-links-to-make-common-tasks-even-quicker"]
 related_links: null
 ---

--- a/articles/extending-in-app-navigation-with-editor-links.mdx
+++ b/articles/extending-in-app-navigation-with-editor-links.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Editor links allow you to link to other sections of the CloudCannon interface from within the Visual Editor. Use them to create edit buttons for your collection items and blog posts to quickly navigate the app. You can also add front matter Editor links to open the front matter Editor at specified fields."
 tags: ["editor","navigation","collections","front matter"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["introducing-the-visual-editor","cloudcannon-protocol"]
 related_links: null
 ---

--- a/articles/extending-your-build-process-with-hooks.mdx
+++ b/articles/extending-your-build-process-with-hooks.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Bash scripts that run at different stages in the build to extend the functionality of your sites. There are three hooks available: Preinstall, Prebuild, and PostBuild. All three are configured using extensionless script files."
 tags: ["builds"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/formatting-your-commit-messages.mdx
+++ b/articles/formatting-your-commit-messages.mdx
@@ -9,9 +9,6 @@ description: >-
   When you save changes, you can provide a message describing the changes to
   refer back to later.
 tags: []
-change_logs:
-  - name: Initial Version
-    _created_at: '2022-12-19 23:26:16 +0000'
 related_articles:
 related_links:
 ---

--- a/articles/getting-started-with-forms-on-cloudcannon.mdx
+++ b/articles/getting-started-with-forms-on-cloudcannon.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "A brief introduction to forms on CloudCannon."
 tags: ["Hosting","Forms"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:28:42 +0000"}]
 related_articles: ["creating-an-inbox-to-receive-your-forms"]
 related_links: null
 ---

--- a/articles/giving-clients-access-to-update-a-site.mdx
+++ b/articles/giving-clients-access-to-update-a-site.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to share a site with your clients without them needing to create a CloudCannon account."
 tags: ["client","sharing","team"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/hosting-your-site-on-a-custom-domain.mdx
+++ b/articles/hosting-your-site-on-a-custom-domain.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Attach your own domain to a site on CloudCannon."
 tags: ["Hosting","Sites","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["hosting-your-site-on-a-subpath","using-cloudcannon-dns-to-configure-your-custom-domain","using-external-dns-to-configure-your-custom-domain"]
 related_links: null
 ---

--- a/articles/hosting-your-site-on-a-subpath.mdx
+++ b/articles/hosting-your-site-on-a-subpath.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Attach your site to the subpath of another site on CloudCannon"
 tags: ["Hosting","Sites","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["hosting-your-site-on-a-custom-domain","using-cloudcannon-dns-to-configure-your-custom-domain","using-external-dns-to-configure-your-custom-domain"]
 related_links: null
 ---

--- a/articles/how-cloudcannon-handles-failed-payments.mdx
+++ b/articles/how-cloudcannon-handles-failed-payments.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "After a failed payment, we try to give you plenty of time to set up a new payment method."
 tags: ["Organizations","Billing"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/how-to-choose-what-input-is-used-in-the-data-editor.mdx
+++ b/articles/how-to-choose-what-input-is-used-in-the-data-editor.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "The Data Editor uses a wide range of different inputs. Each input corresponds to a field in your front matter or data file, providing an editing interface for those values. Inputs have a type, label and a comment."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Input configuration","_created_at":"2021-11-09 02:04:09 +0000"},{"name":"Nested inputs selectors","_created_at":"2022-08-19 01:36:27 +0000"},{"name":"Array subtype example","_created_at":"2022-08-25 04:26:28 +0000"}]
 related_articles: ["using-text-inputs-to-edit-your-data","using-rich-text-inputs-to-edit-your-data","using-social-inputs-to-edit-your-data","using-code-inputs-to-edit-your-data","using-checkbox-inputs-to-edit-your-data","using-color-inputs-to-edit-your-data","using-number-inputs-to-edit-your-data","using-url-inputs-to-edit-your-data","using-date-and-time-inputs-to-edit-your-data","using-upload-inputs-to-edit-your-data","using-select-inputs-to-edit-your-data","editing-objects-in-your-data","using-arrays-to-edit-your-data","using-the-configuration-cascade"]
 related_links: null
 ---

--- a/articles/how-to-manage-the-build-plugin-manually-in-eleventy.mdx
+++ b/articles/how-to-manage-the-build-plugin-manually-in-eleventy.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "By default, CloudCannon injects the eleventy-plugin-cloudcannon package into your site. If defaulty setting clashes with your build, you can manage this manually."
 tags: ["eleventy","builds"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: [{"name":"CloudCannon Eleventy plugin","url":"https://github.com/CloudCannon/eleventy-plugin-cloudcannon"}]
 ---

--- a/articles/how-to-pay-for-cloudcannon.mdx
+++ b/articles/how-to-pay-for-cloudcannon.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "We currently accept Visa and Mastercard credit cards for payment for paid plans and invoicing on Enterprise plans."
 tags: ["Organizations","Billing"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/https-support-for-your-sites-hosted-on-cloudcannon.mdx
+++ b/articles/https-support-for-your-sites-hosted-on-cloudcannon.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Secure your site with SSL."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/including-git-folder-in-your-build.mdx
+++ b/articles/including-git-folder-in-your-build.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: Include your site's .git folder in the build procecss
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-01-13 01:39:29 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/index.mdx
+++ b/articles/index.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "An overview of the benefits of building static sites on CloudCannon."
 tags: ["Beginner"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/integrating-your-dam-with-cloudcannon.mdx
+++ b/articles/integrating-your-dam-with-cloudcannon.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to connect your DAM to your sites in CloudCannon"
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-28 22:50:09 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/integrating-your-forms-with-automate-io.mdx
+++ b/articles/integrating-your-forms-with-automate-io.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Process your form submissions using Automate.io bots."
 tags: ["Hosting","Forms","Guide"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:35:09 +0000"}]
 related_articles: null
 related_links: [{"name":"Automate.io Home","url":"https://automate.io/"},{"name":"Automate.io Documentation","url":"https://docs.automate.io/"}]
 ---

--- a/articles/integrating-your-forms-with-email.mdx
+++ b/articles/integrating-your-forms-with-email.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Receive your form submissions by email."
 tags: ["Hosting","Forms","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:33:45 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/integrating-your-forms-with-ifttt.mdx
+++ b/articles/integrating-your-forms-with-ifttt.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Process your form submissions with IFTTT applets"
 tags: ["Hosting","Forms","Guide"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:40:08 +0000"}]
 related_articles: null
 related_links: [{"name":"IFTTT Home","url":"https://ifttt.com/"},{"name":"IFTTT Documentation","url":"https://ifttt.com/docs"}]
 ---

--- a/articles/integrating-your-forms-with-integromat.mdx
+++ b/articles/integrating-your-forms-with-integromat.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Process your form submissions using Integromat scenarios."
 tags: ["Hosting","Forms","Guide"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 23:35:15 +0000"}]
 related_articles: ["integrating-your-forms-with-make-formerly-integromat"]
 related_links: [{"name":"Integromat Home","url":"https://www.integromat.com/"},{"name":"Integromat Documentation","url":"https://www.integromat.com/en/help/docs"},{"name":"Make Home","url":"https://www.make.com/"}]
 ---

--- a/articles/integrating-your-forms-with-make-formerly-integromat.mdx
+++ b/articles/integrating-your-forms-with-make-formerly-integromat.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Process your form submissions using Make scenarios."
 tags: ["Hosting","Forms","Guide"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:36:36 +0000"}]
 related_articles: null
 related_links: [{"name":"Make Home","url":"https://www.make.com/"},{"name":"Make Documentation","url":"https://www.make.com/help/home"}]
 ---

--- a/articles/integrating-your-forms-with-slack.mdx
+++ b/articles/integrating-your-forms-with-slack.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Send your form submissions to a Slack channel."
 tags: ["Hosting","Forms","Guide"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:40:54 +0000"}]
 related_articles: null
 related_links: [{"name":"Slack Home","url":"https://slack.com/"},{"name":"Slack Resources","url":"https://slack.com/resources"}]
 ---

--- a/articles/integrating-your-forms-with-zapier.mdx
+++ b/articles/integrating-your-forms-with-zapier.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Process your form submissions with Zapier zaps."
 tags: ["Hosting","Forms","Guide"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:39:02 +0000"}]
 related_articles: null
 related_links: [{"name":"Zapier Home","url":"https://zapier.com/"},{"name":"Zapier Help Center","url":"https://zapier.com/help"}]
 ---

--- a/articles/integrating-your-site.mdx
+++ b/articles/integrating-your-site.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Integrating a site in CloudCannon means getting your data and content to an editable state. A good starting point for this process is completing a successful build."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Reworked to include reader","_created_at":"2021-09-23 03:16:14 +0000"}]
 related_articles: ["defining-your-collections"]
 related_links: null
 ---

--- a/articles/introducing-the-content-editor.mdx
+++ b/articles/introducing-the-content-editor.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/editing-editors-content-editor.png"
 description: "Use CloudCannon's Content Editor to give your whole team a straightforward and intuitive editing experience."
 tags: ["content","editor"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: ["defining-editable-regions-in-your-html","configuring-your-markdown-engine"]
 related_links: null
 ---

--- a/articles/introducing-the-data-editor.mdx
+++ b/articles/introducing-the-data-editor.mdx
@@ -12,9 +12,6 @@ tags:
   - Inputs
   - Sidebar
   - Editor panel
-change_logs:
-  - name: Initial Version
-    _created_at: '2021-09-15 05:03:07 +0000'
 related_articles: []
 related_links: []
 ---

--- a/articles/introducing-the-site-dashboard.mdx
+++ b/articles/introducing-the-site-dashboard.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "A breakdown of the main sections of a site."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/introducing-the-source-editor.mdx
+++ b/articles/introducing-the-source-editor.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "A code editor in the browser."
 tags: ["Beginner"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/introducing-the-visual-editor.mdx
+++ b/articles/introducing-the-visual-editor.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Visually navigate and edit the content on your site."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/introducing-your-site-navigation.mdx
+++ b/articles/introducing-your-site-navigation.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn about to get around with your site navigation in CloudCannon."
 tags: ["Site Navigation"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["introducing-the-site-dashboard"]
 related_links: null
 ---

--- a/articles/introduction-to-assets-and-dams.mdx
+++ b/articles/introduction-to-assets-and-dams.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "CloudCannon Assets feature allows you to configure a different platform (DAM) that stores images and documents (e.g. S3, Cloudinary)"
 tags: []
-change_logs: [{"name":"Initial version","_created_at":"2022-03-01 08:18:46 +0000"}]
 related_articles: ["integrating-your-dam-with-cloudcannon","managing-dams-on-your-organisaiton","creating-an-s3-dam","creating-a-tenovos-dam","creating-a-cloudinary-dam"]
 related_links: null
 ---

--- a/articles/introduction-to-building.mdx
+++ b/articles/introduction-to-building.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/i18n-enable-i18n.png"
 description: "TODO"
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: []
 related_links: null
 ---

--- a/articles/introduction-to-syncing.mdx
+++ b/articles/introduction-to-syncing.mdx
@@ -7,7 +7,6 @@ published: true
 image: "ye_olde_images/i18n-enable-i18n.png"
 description: "Your source files are the most important part of any site. Learn how Git works on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-14 00:00:00 +0000"}]
 related_articles:
   - creating-backups-of-your-source-files
   - add-files-with-direct-upload

--- a/articles/keeping-content-consistent-across-files-in-a-collection.mdx
+++ b/articles/keeping-content-consistent-across-files-in-a-collection.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to keep content and data consistent across multiple files in a collection."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-04-19 02:40:59 +0000"}]
 related_articles: ["/articles/defining-the-default-contents-of-new-files"]
 related_links: null
 ---

--- a/articles/legacy-form-documentation.mdx
+++ b/articles/legacy-form-documentation.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Create forms on your site and send the submissions to an email address or integrate with your own workflows."
 tags: ["forms","webhooks","hosting"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-17 02:43:43 +0000"}]
 related_articles: ["reducing-spam-by-adding-google-recaptcha"]
 related_links: [{"name":"Zapier","url":"https://zapier.com/"},{"name":"Zapier Documentation","url":"https://zapier.com/help/create/code-webhooks"},{"name":"Automate","url":"https://automate.io/"},{"name":"Automate Documentation","url":"https://docs.automate.io/en/articles/1305409-webhooks"},{"name":"IFTTT","url":"https://ifttt.com/"},{"name":"IFTTT FAQ","url":"https://help.ifttt.com/hc/en-us/articles/115010230347-The-Webhooks-Service"}]
 ---

--- a/articles/legacy-forms-migration-guide.mdx
+++ b/articles/legacy-forms-migration-guide.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "A guide to migrating from legacy CloudCannon forms to the new CloudCannon forms"
 tags: ["Hosting","Forms","Guide"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 23:42:40 +0000"}]
 related_articles: ["getting-started-with-forms-on-cloudcannon"]
 related_links: null
 ---

--- a/articles/live-editing-with-svelte.mdx
+++ b/articles/live-editing-with-svelte.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Data previews on CloudCannon with Svelte. Edit Front Matter and see the changes show up live."
 tags: ["Data previews","svelte","sveltekit"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-10-17 06:54:28 +0000"}]
 related_articles: ["what-is-live-editing","using-live-editing-with-vanilla-js"]
 related_links: [{"name":"@cloudcannon/svelte-connector","url":"https://www.npmjs.com/package/@cloudcannon/svelte-connector"},{"name":"GitHub","url":"https://github.com/CloudCannon/svelte-connector"}]
 ---

--- a/articles/managing-your-connected-dams.mdx
+++ b/articles/managing-your-connected-dams.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to update the details of your connected DAMs"
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:30:24 +0000"},{"name":"Add note on site uploads","_created_at":"2022-08-19 02:07:56 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/managing-your-node-version-with-nvm.mdx
+++ b/articles/managing-your-node-version-with-nvm.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "CloudCannon uses the LTS version of Node.js by default. You can use nvm to select which node version to use with your build."
 tags: ["build","environment","node"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Updated list of node versions","_created_at":"2022-02-22 20:41:46 +0000"}]
 related_articles: null
 related_links: [{"name":"Node.js Home","url":"https://nodejs.org/"},{"name":"nvm Documentation","url":"https://github.com/nvm-sh/nvm"},{"name":"Yarn Home","url":"https://classic.yarnpkg.com/lang/en/"}]
 ---

--- a/articles/managing-your-ruby-version.mdx
+++ b/articles/managing-your-ruby-version.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "CloudCannon supports Ruby versions using rbenv. Jekyll sites without the version specified default to version 2.7.x."
 tags: ["builds","environment","ruby","jekyll"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: [{"name":"Installing Ruby","url":"https://github.com/rbenv/rbenv#installation"}]
 ---

--- a/articles/managing-your-team-members.mdx
+++ b/articles/managing-your-team-members.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "After creating an Organization, your account is set up as the owner. There are 4 main types of users in an Organization."
 tags: ["Organizations","team","sharing"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/migrating-to-global-configuration-files.mdx
+++ b/articles/migrating-to-global-configuration-files.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "How you set global configuration in CloudCannon has changed. We recommend updating, but the previous configuration will continue to work. CloudCannon now uses specific files rather than relying on your SSG configuration files."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-01-17 02:18:20 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/migrating-to-input-configuration.mdx
+++ b/articles/migrating-to-input-configuration.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "How you configure inputs in CloudCannon has changed. We recommend updating, but the previous configuration will continue to work. There's now a consolidated key that encompasses our previous keys."
 tags: []
-change_logs: [{"name":"Initial version","_created_at":"2021-11-11 04:01:08 +0000"}]
 related_articles: ["using-text-inputs-to-edit-your-data","using-rich-text-inputs-to-edit-your-data","using-social-inputs-to-edit-your-data","using-code-inputs-to-edit-your-data","using-checkbox-inputs-to-edit-your-data","using-color-inputs-to-edit-your-data","using-number-inputs-to-edit-your-data","using-url-inputs-to-edit-your-data","using-date-and-time-inputs-to-edit-your-data","using-upload-inputs-to-edit-your-data","using-select-inputs-to-edit-your-data","editing-objects-in-your-data","using-arrays-to-edit-your-data","using-the-configuration-cascade"]
 related_links: null
 ---

--- a/articles/migrating-to-preview-options.mdx
+++ b/articles/migrating-to-preview-options.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "How to migrate from our legacy preview option keys to the latest consolidated preview option."
 tags: ["migration"]
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-14 03:02:12 +0000"}]
 related_articles: ["/articles/defining-your-collections","/articles/creating-collection-schemas","/articles/array-structures-reference","/articles/editing-objects-in-your-data","/articles/using-arrays-to-edit-your-data"]
 related_links: null
 ---

--- a/articles/netlify-hosting-with-cloudcannon-editing.mdx
+++ b/articles/netlify-hosting-with-cloudcannon-editing.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Connect CloudCannon and Netlify to the same Git repo to enable both CloudCannon editing and Netlify builds and deployment."
 tags: ["deploy","hosting","netlify"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-12-12 21:24:08 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/optimizing-your-build-by-minifying-css-and-javascript.mdx
+++ b/articles/optimizing-your-build-by-minifying-css-and-javascript.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "CloudCannon optimizes sites to load as fast as possible. CloudCannon minifies CSS with clean-css and JavaScript with esbuild. Externally hosted assets are not optimized."
 tags: ["compressor","optimization","builds"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: [{"name":"Clean-CSS","url":"https://github.com/GoalSmashers/clean-css"},{"name":"esbuild","url":"https://esbuild.github.io/"}]
 ---

--- a/articles/output-a-built-site-from-cloudcannon-to-an-external-provider.mdx
+++ b/articles/output-a-built-site-from-cloudcannon-to-an-external-provider.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Configure a Build Deploy to commit the built version of your site to a repository."
 tags: ["deploys","output","git","repository","builds"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/patching-yaml-number-parsing-for-jekyll.mdx
+++ b/articles/patching-yaml-number-parsing-for-jekyll.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: null
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-10-05 01:13:43 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/post-processing.mdx
+++ b/articles/post-processing.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Configure CloudCannon processes that run after your site builds."
 tags: ["forms","inbox","encryption","security"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["creating-a-form-for-your-site-on-cloudcannon","reading-form-submissions-in-your-inbox"]
 related_links: null
 ---

--- a/articles/pre-configure-your-site-before-creation-on-cloudcannon.mdx
+++ b/articles/pre-configure-your-site-before-creation-on-cloudcannon.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to pre-configure your site with code, before uploading it to CloudCannon."
 tags: ["builds"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-12-01 22:20:50 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/preventing-the-global-cloudcannon-live-editing-object.mdx
+++ b/articles/preventing-the-global-cloudcannon-live-editing-object.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "CloudCannon injects an object onto the window object when viewed in the Visual Editor. This article will show how to turn off this behavior."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["what-is-live-editing","using-live-editing-with-vanilla-js","using-live-editing-with-react"]
 related_links: null
 ---

--- a/articles/reading-form-submissions-in-your-inbox.mdx
+++ b/articles/reading-form-submissions-in-your-inbox.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Once you have correctly added a form to your site, you can view responses in the CloudCannon inbox. "
 tags: ["Hosting","Forms","Sites","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["creating-a-form-for-your-site-on-cloudcannon"]
 related_links: null
 ---

--- a/articles/recovering-access-to-your-organization.mdx
+++ b/articles/recovering-access-to-your-organization.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Resolve Organization ownership conflicts."
 tags: ["Organizations","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: [{"name":"Forgotten password form","url":"https://app.cloudcannon.com/users/password/new"}]
 ---

--- a/articles/reducing-spam-by-adding-google-recaptcha.mdx
+++ b/articles/reducing-spam-by-adding-google-recaptcha.mdx
@@ -7,7 +7,6 @@ published: null
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Protect form submissions from automated spam."
 tags: ["Hosting","Forms","Sites","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["reducing-spam-by-adding-hcaptcha"]
 related_links: [{"name":"Recaptcha Home","url":"https://developers.google.com/recaptcha/"},{"name":"Recaptcha Documentation","url":"https://developers.google.com/recaptcha/docs/display"}]
 ---

--- a/articles/reducing-spam-by-adding-hcaptcha.mdx
+++ b/articles/reducing-spam-by-adding-hcaptcha.mdx
@@ -7,7 +7,6 @@ published: null
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Protect form submissions from automated spam."
 tags: ["Hosting","Forms","Sites","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-18 02:19:33 +0000"}]
 related_articles: ["reducing-spam-by-adding-google-recaptcha"]
 related_links: [{"name":"hCaptcha Home","url":"https://www.hcaptcha.com/"},{"name":"hCaptcha Documentation","url":"https://docs.hcaptcha.com/"}]
 ---

--- a/articles/resolving-ownership-over-a-custom-domain.mdx
+++ b/articles/resolving-ownership-over-a-custom-domain.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "When resolving ownership issues, we do our best to protect all parties involved during these processes. If we are asking for proof of ownership, it is well-intentioned."
 tags: ["Organizations","Guides","domain","support"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: [{"name":"Contact Support","url":"mailto:support@cloudcannon.com"}]
 ---

--- a/articles/saving-files-from-your-build-back-to-your-source.mdx
+++ b/articles/saving-files-from-your-build-back-to-your-source.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "You can configure CloudCannon to commit built/generated files back to your source repository. This ensures that any generated files are consistent between CloudCannon and your source repository."
 tags: ["builds","environment","git","syncing"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/scheduling-your-builds-manually.mdx
+++ b/articles/scheduling-your-builds-manually.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Manually scheduled builds are configured in the CloudCannon UI. They are useful for regular period builds or one-off future builds."
 tags: ["schedule","builds"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/scheduling-your-next-build-automatically.mdx
+++ b/articles/scheduling-your-next-build-automatically.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "After building your site, CloudCannon will read your _schedule.txt file and automatically configure a build at the specified time."
 tags: ["builds","schedule"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: [{"name":"Jekyll CloudCannon Schedule","url":"https://github.com/CloudCannon/jekyll-cloudcannon-schedule"}]
 ---

--- a/articles/setting-global-configuration.mdx
+++ b/articles/setting-global-configuration.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Global configuration for your site is read from a file. The configuration is the mostly the same across SSGs with some minor differences."
 tags: []
-change_logs: [{"name":"Initial version","_created_at":"2021-12-21 03:11:36 +0000"}]
 related_articles: ["defining-your-collections"]
 related_links: null
 ---

--- a/articles/setting-up-a-publish-branch-with-merging-or-pull-requests.mdx
+++ b/articles/setting-up-a-publish-branch-with-merging-or-pull-requests.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to set up a publish branch with merging or pull requests, with CloudCannon."
 tags: ["branch","git","publish"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-24 00:53:28 +0000"}]
 related_articles: ["enabling-editor-branching-with-projects","editor-merging-and-pull-requests-with-publishing"]
 related_links: null
 ---

--- a/articles/sharing-on-a-per-site-basis.mdx
+++ b/articles/sharing-on-a-per-site-basis.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Share a site with others by creating Collaborators."
 tags: ["Sites","Sharing","Guides","collaborators"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["managing-your-team-members"]
 related_links: null
 ---

--- a/articles/transferring-sites-between-organizations.mdx
+++ b/articles/transferring-sites-between-organizations.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Transfer the ownership of a site to another Organization."
 tags: ["Organizations","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/unlisting-files-in-a-collection.mdx
+++ b/articles/unlisting-files-in-a-collection.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Hide specific files in a collection so your team members don't accidentally edit them. These files are still used in your site build."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-23 04:59:48 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/using-a-modal-with-array-structures.mdx
+++ b/articles/using-a-modal-with-array-structures.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "A modal with search, tagging, and bigger images is available when the number of structures you add becomes far too many to manage with a dropdown."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["using-arrays-to-edit-your-data","array-structures-reference"]
 related_links: null
 ---

--- a/articles/using-arrays-to-edit-your-data.mdx
+++ b/articles/using-arrays-to-edit-your-data.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "These inputs are for editing ordered lists of values in your data. Array inputs are grouped lists of inputs in the data editor. They are used for a wide range of use cases, ranging from small text lists to full component builders."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"},{"name":"Input configuration","_created_at":"2021-11-08 00:30:04 +0000"},{"name":"Added preview options","_created_at":"2022-11-21 23:39:34 +0000"}]
 related_articles: ["how-to-choose-what-input-is-used-in-the-data-editor","using-the-configuration-cascade","editing-objects-in-your-data","defining-what-adds-to-an-array-with-array-structures","array-structures-reference","changing-how-cards-preview-your-data"]
 related_links: [{"name":"Material Icons","url":"https://material.io/tools/icons/"}]
 ---

--- a/articles/using-arrays-to-make-a-gallery.mdx
+++ b/articles/using-arrays-to-make-a-gallery.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to set the structure for new items in a gallery array."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["using-arrays-to-edit-your-data"]
 related_links: null
 ---

--- a/articles/using-bearer-tokens-to-authenticate-with-your-site.mdx
+++ b/articles/using-bearer-tokens-to-authenticate-with-your-site.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Require a secret token in your request headers to authenticate the request."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/using-checkbox-inputs-to-edit-your-data.mdx
+++ b/articles/using-checkbox-inputs-to-edit-your-data.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "These inputs are for editing true/false values in your data. They can be triggered on or off."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"},{"name":"Input configuration","_created_at":"2021-11-04 03:34:07 +0000"}]
 related_articles: ["how-to-choose-what-input-is-used-in-the-data-editor","using-the-configuration-cascade"]
 related_links: null
 ---

--- a/articles/using-cloudcannon-dns-to-configure-your-custom-domain.mdx
+++ b/articles/using-cloudcannon-dns-to-configure-your-custom-domain.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "A fast, scalable DNS service automatically configured for your site."
 tags: ["DNS","domain","hosting"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["hosting-your-site-on-a-custom-domain","hosting-your-site-on-a-subpath","using-cloudcannon-dns-to-configure-your-custom-domain","using-external-dns-to-configure-your-custom-domain"]
 related_links: null
 ---

--- a/articles/using-code-inputs-to-edit-your-data.mdx
+++ b/articles/using-code-inputs-to-edit-your-data.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Code editor input for blocks of code or mono-space plain text."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"},{"name":"Input configuration","_created_at":"2021-11-04 03:41:55 +0000"}]
 related_articles: ["how-to-choose-what-input-is-used-in-the-data-editor","using-the-configuration-cascade"]
 related_links: null
 ---

--- a/articles/using-color-inputs-to-edit-your-data.mdx
+++ b/articles/using-color-inputs-to-edit-your-data.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Color picker input with spectrum and transparency controls for editing color values in your data."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"},{"name":"Input configuration","_created_at":"2021-11-04 03:48:59 +0000"}]
 related_articles: ["how-to-choose-what-input-is-used-in-the-data-editor","using-the-configuration-cascade"]
 related_links: null
 ---

--- a/articles/using-date-and-time-inputs-to-edit-your-data.mdx
+++ b/articles/using-date-and-time-inputs-to-edit-your-data.mdx
@@ -7,13 +7,6 @@ published: true
 image: /uploads/CloudCannonDocumentationog.jpg
 description: These inputs are for editing date and time values in your data.
 tags: []
-change_logs:
-  - name: Initial Version
-    _created_at: '2021-09-15 05:03:07 +0000'
-  - name: Input configuration
-    _created_at: '2021-11-05 01:02:51 +0000'
-  - name: Added timezone option
-    _created_at: '2022-05-18 05:20:58 +0000'
 related_articles:
 related_links:
   - name: List of tz database time zones

--- a/articles/using-external-dns-to-configure-your-custom-domain.mdx
+++ b/articles/using-external-dns-to-configure-your-custom-domain.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Use your own DNS servers."
 tags: ["hosting","dns","domain"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["using-cloudcannon-dns-to-configure-your-custom-domain"]
 related_links: [{"name":"iwantmyname DNS Documentation","url":"https://help.iwantmyname.com/hc/en-gb/categories/360002768037-DNS-Nameservers"},{"name":"Namecheap FreeDNS","url":"https://www.namecheap.com/domains/freedns.aspx"},{"name":"GoDaddy DNS Documentation","url":"https://www.godaddy.com/help/managing-dns-for-your-domain-names-680"}]
 ---

--- a/articles/using-geolocation-to-detect-your-users-country.mdx
+++ b/articles/using-geolocation-to-detect-your-users-country.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Customize content based on the location of the visitor."
 tags: ["Hosting","Sites","Guides","i18n"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["adding-i18n-to-your-site-for-global-audiences"]
 related_links: null
 ---

--- a/articles/using-git-lfs.mdx
+++ b/articles/using-git-lfs.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Git LFS is used to store large files outside your repository, but use continue using them as if they were part of it. It's a great way to maintain a small repository size for faster syncing and builds, while keeping the external services you rely on the same."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-08-17 22:43:11 +0000"}]
 related_articles: null
 related_links: [{"name":"Git LFS","url":"https://git-lfs.github.com/"},{"name":"Bitbucket Git LFS instructions","url":"https://support.atlassian.com/bitbucket-cloud/docs/use-git-lfs-with-bitbucket/"},{"name":"GitHub Git LFS instructions","url":"https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage"},{"name":"GitLab Git LFS instructions","url":"https://docs.gitlab.com/ee/topics/git/lfs/"}]
 ---

--- a/articles/using-live-editing-with-react.mdx
+++ b/articles/using-live-editing-with-react.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Live editing on CloudCannon with React. Edit Front Matter and see the changes show up live."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["what-is-live-editing","using-live-editing-with-vanilla-js","preventing-the-global-cloudcannon-live-editing-object"]
 related_links: null
 ---

--- a/articles/using-live-editing-with-vanilla-js.mdx
+++ b/articles/using-live-editing-with-vanilla-js.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Live editing on CloudCannon with vanilla JS. Create your own live previews by hooking into document events."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Fixed event detail reference and added an async function around the CloudCannon.get call","_created_at":"2021-09-30 22:27:03 +0000"}]
 related_articles: ["what-is-live-editing","using-live-editing-with-react","preventing-the-global-cloudcannon-live-editing-object"]
 related_links: null
 ---

--- a/articles/using-number-inputs-to-edit-your-data.mdx
+++ b/articles/using-number-inputs-to-edit-your-data.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "These inputs are for editing numerical values in your data."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"},{"name":"Input configuration","_created_at":"2021-11-04 03:56:15 +0000"}]
 related_articles: ["how-to-choose-what-input-is-used-in-the-data-editor","using-the-configuration-cascade"]
 related_links: null
 ---

--- a/articles/using-rich-text-inputs-to-edit-your-data.mdx
+++ b/articles/using-rich-text-inputs-to-edit-your-data.mdx
@@ -10,9 +10,6 @@ description: >-
   These inputs give your editors ultimate control by allowing them to write
   markup directly into your data files.
 tags: []
-change_logs:
-  - name: Initial Version
-    _created_at: '2021-09-15 05:03:07 +0000'
 related_articles: []
 related_links: []
 ---

--- a/articles/using-select-inputs-to-edit-your-data.mdx
+++ b/articles/using-select-inputs-to-edit-your-data.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "These inputs are for values from a fixed or dynamic set of options. Useful for linking across pages, collections and data sets."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Input configuration","_created_at":"2021-11-04 02:19:45 +0000"},{"name":"Add Choice and Multichoice","_created_at":"2022-08-19 01:50:16 +0000"},{"name":"Add preview options","_created_at":"2022-11-16 04:15:00 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/using-social-inputs-to-edit-your-data.mdx
+++ b/articles/using-social-inputs-to-edit-your-data.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "These inputs are for editing plain text in your data. Each input includes a specific brand icon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"},{"name":"Input configuration","_created_at":"2021-11-05 01:35:16 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/using-sso-to-create-team-accounts.mdx
+++ b/articles/using-sso-to-create-team-accounts.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Enforce Single Sign On for your team members and increase security by using CloudCannon with SAML."
 tags: ["Organizations","Authentication","Sharing","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/using-text-inputs-to-edit-your-data.mdx
+++ b/articles/using-text-inputs-to-edit-your-data.mdx
@@ -9,9 +9,6 @@ description: >-
   Details for setting up and using different types of plain text inputs for
   editing your data.
 tags: []
-change_logs:
-  - name: Initial Version
-    _created_at: '2021-09-15 05:03:07 +0000'
 related_articles:
 related_links:
 ---

--- a/articles/using-the-configuration-cascade.mdx
+++ b/articles/using-the-configuration-cascade.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "CloudCannon offers different configuration options for each input and editor. Use this to improve the editing experience for your sites. Configuration can be set from a number of sources, from lowest priority to highest."
 tags: ["Markup","Images"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Added schema source level","_created_at":"2022-11-23 23:00:22 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/using-upload-inputs-to-edit-your-data.mdx
+++ b/articles/using-upload-inputs-to-edit-your-data.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "These inputs allow editors to upload new files, select existing images, or link to external files."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"},{"name":"Input configuration","_created_at":"2021-11-04 02:03:45 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/using-url-inputs-to-edit-your-data.mdx
+++ b/articles/using-url-inputs-to-edit-your-data.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Single line input for relative, absolute and fully qualified URLs. URL inputs show a preview of the target."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 05:03:07 +0000"},{"name":"Input configuration","_created_at":"2021-11-04 01:46:45 +0000"}]
 related_articles: ["how-to-choose-what-input-is-used-in-the-data-editor","using-the-configuration-cascade"]
 related_links: null
 ---

--- a/articles/viewing-your-form-submissions-in-cloudcannon.mdx
+++ b/articles/viewing-your-form-submissions-in-cloudcannon.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "View all your form submissions in CloudCannon."
 tags: ["Hosting","Forms"]
-change_logs: [{"name":"Initial Version","_created_at":"2022-03-01 03:33:04 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/viewing-your-site-on-a-testing-domain.mdx
+++ b/articles/viewing-your-site-on-a-testing-domain.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Every site on CloudCannon has a matching .cloudvent.net URL. Use this to test on a live site, without having to set up your own domain."
 tags: ["Hosting","Sites","Guides"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["adding-password-authentication-to-your-site"]
 related_links: [{"name":"Contact Support","url":"/contact"}]
 ---

--- a/articles/visual-data-bindings-with-bookshop.mdx
+++ b/articles/visual-data-bindings-with-bookshop.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Bookshop will automatically add data bindings when live editing in CloudCannon"
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["what-is-live-editing","using-live-editing-with-vanilla-js","preventing-the-global-cloudcannon-live-editing-object"]
 related_links: null
 ---

--- a/articles/visual-data-bindings-with-react.mdx
+++ b/articles/visual-data-bindings-with-react.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "React allows you to add the `data-cms-bind` attribute on any DOM element"
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["what-is-live-editing","using-live-editing-with-vanilla-js","preventing-the-global-cloudcannon-live-editing-object"]
 related_links: null
 ---

--- a/articles/visual-data-previews-with-bookshop.mdx
+++ b/articles/visual-data-previews-with-bookshop.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "TODO"
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["what-is-live-editing","using-live-editing-with-vanilla-js","preventing-the-global-cloudcannon-live-editing-object"]
 related_links: null
 ---

--- a/articles/what-are-visual-data-bindings.mdx
+++ b/articles/what-are-visual-data-bindings.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "TODO"
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["visual-data-bindings-with-react","visual-data-bindings-with-bookshop","cloudcannon-protocol"]
 related_links: null
 ---

--- a/articles/what-is-an-organization.mdx
+++ b/articles/what-is-an-organization.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Organizations help you organize your team, sites and resources in one place."
 tags: ["Organizations"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/articles/what-is-live-editing.mdx
+++ b/articles/what-is-live-editing.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Live editing on CloudCannon lets your editors see exactly what they are changing as they change it."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"}]
 related_articles: ["using-live-editing-with-react","using-live-editing-with-vanilla-js","preventing-the-global-cloudcannon-live-editing-object"]
 related_links: null
 ---

--- a/articles/what-version-of-go-is-used-in-the-build-environment.mdx
+++ b/articles/what-version-of-go-is-used-in-the-build-environment.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Currently, the only installed Go version is 1.15.7-linux/amd64."
 tags: ["builds","environment","golang","hugo"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Update version information","_created_at":"2022-02-22 22:07:01 +0000"}]
 related_articles: null
 related_links: [{"name":"Hugo Home","url":"https://gohugo.io/"},{"name":"Embedded Dart Sass Documentation","url":"https://github.com/sass/dart-sass-embedded"},{"name":"Go Home","url":"https://go.dev/"}]
 ---

--- a/articles/why-cloudcannon-injects-width-and-height-onto-images.mdx
+++ b/articles/why-cloudcannon-injects-width-and-height-onto-images.mdx
@@ -7,7 +7,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "CloudCannon automatically adds size attributes (width, height, sizes) to the HTML for images uploaded in the Content Editor and Editable Regions."
 tags: ["Markup","Images"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-15 23:13:40 +0000"},{"name":"Added image_size_attributes note","_created_at":"2022-03-14 22:55:17 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/cloudcannon.config.cjs
+++ b/cloudcannon.config.cjs
@@ -75,14 +75,6 @@ module.exports = {
         }
     },
     _structures: {
-        change_logs: {
-            values: {
-                value: {
-                    name: 'Initial Version',
-                    _created_at: null 
-                }
-            }
-        },
         related_links: {
             values: {
                 value: {

--- a/guides/astro-starter-guide/building.mdx
+++ b/guides/astro-starter-guide/building.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Astro site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/astro-starter-guide/configuring.mdx
+++ b/guides/astro-starter-guide/configuring.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Astro site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/astro-starter-guide/finished.mdx
+++ b/guides/astro-starter-guide/finished.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Astro site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/astro-starter-guide/index.mdx
+++ b/guides/astro-starter-guide/index.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Astro site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/astro-starter-guide/syncing.mdx
+++ b/guides/astro-starter-guide/syncing.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Astro site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/astro-starter-guide/visual-editing.mdx
+++ b/guides/astro-starter-guide/visual-editing.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Astro site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/eleventy-cms-get-started-with-cloudcannon/a-tour-of-cloudcannon.mdx
+++ b/guides/eleventy-cms-get-started-with-cloudcannon/a-tour-of-cloudcannon.mdx
@@ -9,7 +9,6 @@ published: true
 image: https://dam-cdn.cloudcannon.com/eleventy-cloudcannon-tutorial-social.png
 description: "A brief tour of the pages and features on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/eleventy-cms-get-started-with-cloudcannon/collaborating-with-your-team.mdx
+++ b/guides/eleventy-cms-get-started-with-cloudcannon/collaborating-with-your-team.mdx
@@ -9,7 +9,6 @@ published: true
 image: https://dam-cdn.cloudcannon.com/eleventy-cloudcannon-tutorial-social.png
 description: "An overview of collaborating with your team using CloudCannon."
 tags: []
-change_logs: []
 related_articles: null
 related_links: []
 ---

--- a/guides/eleventy-cms-get-started-with-cloudcannon/editing-interfaces.mdx
+++ b/guides/eleventy-cms-get-started-with-cloudcannon/editing-interfaces.mdx
@@ -9,7 +9,6 @@ published: true
 image: https://dam-cdn.cloudcannon.com/eleventy-cloudcannon-tutorial-social.png
 description: "An overview of the editing interfaces available on CloudCannon."
 tags: []
-change_logs: []
 related_articles: null
 related_links: []
 ---

--- a/guides/eleventy-cms-get-started-with-cloudcannon/fine-tuning-the-editing-experience.mdx
+++ b/guides/eleventy-cms-get-started-with-cloudcannon/fine-tuning-the-editing-experience.mdx
@@ -9,7 +9,6 @@ published: true
 image: https://dam-cdn.cloudcannon.com/eleventy-cloudcannon-tutorial-social.png
 description: "Eleventy content structure on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/eleventy-cms-get-started-with-cloudcannon/index.mdx
+++ b/guides/eleventy-cms-get-started-with-cloudcannon/index.mdx
@@ -9,7 +9,6 @@ published: true
 image: https://dam-cdn.cloudcannon.com/eleventy-cloudcannon-tutorial-social.png
 description: "Learn how to get your website set up on the CloudCannon Eleventy CMS."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/eleventy-cms-get-started-with-cloudcannon/onwards.mdx
+++ b/guides/eleventy-cms-get-started-with-cloudcannon/onwards.mdx
@@ -9,7 +9,6 @@ published: true
 image: https://dam-cdn.cloudcannon.com/eleventy-cloudcannon-tutorial-social.png
 description: "Final words."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/gatsby-starter-guide/building.mdx
+++ b/guides/gatsby-starter-guide/building.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Gatsby site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/gatsby-starter-guide/complete.mdx
+++ b/guides/gatsby-starter-guide/complete.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Gatsby site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/gatsby-starter-guide/configuring.mdx
+++ b/guides/gatsby-starter-guide/configuring.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Gatsby site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/gatsby-starter-guide/index.mdx
+++ b/guides/gatsby-starter-guide/index.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Gatsby site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/gatsby-starter-guide/syncing.mdx
+++ b/guides/gatsby-starter-guide/syncing.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Gatsby site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/gatsby-starter-guide/visual-editing.mdx
+++ b/guides/gatsby-starter-guide/visual-editing.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Gatsby site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/getting-started/adding-your-brand-to-your-cloudcannon-account.mdx
+++ b/guides/getting-started/adding-your-brand-to-your-cloudcannon-account.mdx
@@ -9,7 +9,6 @@ order: 6
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to make your CloudCannon account feel like home by adding your own custom branding."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-27 02:57:05 +0000"}]
 related_articles: ["customizing-cloudcannon-to-match-your-brand"]
 related_links: null
 ---

--- a/guides/getting-started/configuring-your-cms.mdx
+++ b/guides/getting-started/configuring-your-cms.mdx
@@ -9,7 +9,6 @@ order: 3
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn about the three primary ways to configure your CloudCannon CMS. "
 tags: ["Components","CMS","Editing"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-22 03:21:36 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/getting-started/connecting-your-first-site.mdx
+++ b/guides/getting-started/connecting-your-first-site.mdx
@@ -9,7 +9,6 @@ order: 2
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to connect your existing site to CloudCannon."
 tags: ["syncing","building"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-21 04:53:27 +0000"}]
 related_articles: ["connecting-a-github-repository-as-your-source","connecting-a-gitlab-respository-as-your-source","connecting-a-bitbucket-respository-as-your-source","connecting-a-self-hosted-gitlab-repository-as-your-source","configuring-your-build","add-files-with-direct-upload"]
 related_links: null
 ---

--- a/guides/getting-started/creating-a-project-from-a-site.mdx
+++ b/guides/getting-started/creating-a-project-from-a-site.mdx
@@ -9,7 +9,6 @@ order: 4
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how you Git-based workflows in the CloudCannon CMS"
 tags: ["Git","Branching","Staging"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-22 03:42:46 +0000"}]
 related_articles: ["enabling-editor-branching-with-projects","editor-merging-and-pull-requests-with-publishing"]
 related_links: null
 ---

--- a/guides/getting-started/hosting-your-live-site.mdx
+++ b/guides/getting-started/hosting-your-live-site.mdx
@@ -9,7 +9,6 @@ order: 7
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn about your options for hosting a site with CloudCannon."
 tags: ["Hosting"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-27 03:30:36 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/getting-started/how-to-work-with-your-team-and-clients.mdx
+++ b/guides/getting-started/how-to-work-with-your-team-and-clients.mdx
@@ -9,7 +9,6 @@ order: 5
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Learn how to add your team members to CloudCannon, and share editing with those outside of your team."
 tags: ["Team members","Collaborators","Client sharing"]
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-27 03:19:20 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/getting-started/index.mdx
+++ b/guides/getting-started/index.mdx
@@ -9,7 +9,6 @@ order: 1
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "Explore the CloudCannon CMS with one of our simple templates."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2021-09-27 02:30:18 +0000"}]
 related_articles: ["connecting-your-first-site"]
 related_links: null
 ---

--- a/guides/hugo-starter-guide/a-tour-of-cloudcannon.mdx
+++ b/guides/hugo-starter-guide/a-tour-of-cloudcannon.mdx
@@ -9,7 +9,6 @@ published: true
 image: https://dam-cdn.cloudcannon.com/community/Tutorial+social+image.png
 description: "A brief tour of the pages and features on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/hugo-starter-guide/collaborating-with-your-team.mdx
+++ b/guides/hugo-starter-guide/collaborating-with-your-team.mdx
@@ -9,7 +9,6 @@ published: true
 image: https://dam-cdn.cloudcannon.com/community/Tutorial+social+image.png
 description: "An overview of collaborating with your team using CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/hugo-starter-guide/editing-interfaces.mdx
+++ b/guides/hugo-starter-guide/editing-interfaces.mdx
@@ -9,7 +9,6 @@ published: true
 image: https://dam-cdn.cloudcannon.com/community/Tutorial+social+image.png
 description: "An overview of the editing interfaces available on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/hugo-starter-guide/fine-tuning-the-editing-experience.mdx
+++ b/guides/hugo-starter-guide/fine-tuning-the-editing-experience.mdx
@@ -9,7 +9,6 @@ published: true
 image: https://dam-cdn.cloudcannon.com/community/Tutorial+social+image.png
 description: "Hugo content structure on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/hugo-starter-guide/index.mdx
+++ b/guides/hugo-starter-guide/index.mdx
@@ -9,7 +9,6 @@ published: true
 image: https://dam-cdn.cloudcannon.com/community/Tutorial+social+image.png
 description: "Learn how to get your website set up on the CloudCannon Hugo CMS."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/nextjs-starter-guide/building.mdx
+++ b/guides/nextjs-starter-guide/building.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Next.js site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/nextjs-starter-guide/complete.mdx
+++ b/guides/nextjs-starter-guide/complete.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Next.js site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/nextjs-starter-guide/configuring.mdx
+++ b/guides/nextjs-starter-guide/configuring.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Next.js site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/nextjs-starter-guide/index.mdx
+++ b/guides/nextjs-starter-guide/index.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Next.js site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/nextjs-starter-guide/syncing.mdx
+++ b/guides/nextjs-starter-guide/syncing.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Next.js site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/nextjs-starter-guide/visual-editing.mdx
+++ b/guides/nextjs-starter-guide/visual-editing.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your Next.js site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2022-02-03 00:32:03 +0000"}]
 related_articles: null
 related_links: null
 ---

--- a/guides/sveltekit-starter-guide/building.mdx
+++ b/guides/sveltekit-starter-guide/building.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your SvelteKit site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/sveltekit-starter-guide/configuring.mdx
+++ b/guides/sveltekit-starter-guide/configuring.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your SvelteKit site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/sveltekit-starter-guide/finished.mdx
+++ b/guides/sveltekit-starter-guide/finished.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your SvelteKit site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/sveltekit-starter-guide/index.mdx
+++ b/guides/sveltekit-starter-guide/index.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your SvelteKit site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/sveltekit-starter-guide/syncing.mdx
+++ b/guides/sveltekit-starter-guide/syncing.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your SvelteKit site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/guides/sveltekit-starter-guide/visual-editing.mdx
+++ b/guides/sveltekit-starter-guide/visual-editing.mdx
@@ -9,7 +9,6 @@ published: true
 image: "/documentation/static/CloudCannonDocumentationog.jpg"
 description: "This guide will walk through the steps required to get your SvelteKit site built, editable and live on CloudCannon."
 tags: []
-change_logs: [{"name":"Initial Version","_created_at":"2023-02-01 02:40:30 +0000"}]
 related_articles: null
 related_links: []
 ---

--- a/schemas/article.mdx
+++ b/schemas/article.mdx
@@ -7,7 +7,6 @@ published: true
 image: /uploads/CloudCannonDocumentationog.jpg
 description:
 tags: []
-change_logs: []
 related_articles: []
 related_links: []
 ---


### PR DESCRIPTION
Unused field pulled across from old site — no longer relevant with a public repository.