### PR TITLE
Configure basic commit messages in CloudCannon

### DIFF
--- a/cloudcannon.config.cjs
+++ b/cloudcannon.config.cjs
@@ -95,5 +95,8 @@ module.exports = {
         _uuid: {
             instance_value: 'UUID',
         }
-    }
+    },
+    commit_templates: [
+        {template_string: '{message}'}
+    ]
 }


### PR DESCRIPTION
Add some config to allow commit messages to be written from CloudCannon. When a message isn't supplied, CloudCannon's default commit messages will still be used.