### PR TITLE
Explanation for the values used in _schedule.txt

### DIFF
--- a/articles/scheduling-your-next-build-automatically.mdx
+++ b/articles/scheduling-your-next-build-automatically.mdx
@@ -16,25 +16,24 @@ Automatic builds are configured by creating a `_schedule.txt` file in your site.
 ### Schedule file format
 
 
-The `_schedule.txt` is a comma separated list of values. It contains three values:
+The `_schedule.txt` is a comma separated list of values. It contains three values, which are used to schedule a build and generate the management UI.
 
-1. Run date
-2. Build name
-3. Source filename
+
+1. **Run date**: Defines the date and time your build will be scheduled for.
+2. **Build name**: A label that will be shown in the Scheduled Builds UI in CloudCannon.
+3. **Source filename**: Path to a source file. The UI will show a button linking to the editor for that file. This is useful if you're scheduling a build to publish a particular file.
 
 For example:
 
 <comp.CodeBlock language="plaintext" source="_schedule.txt">
 ```
 2020-10-22T10:00:00+00:00,Publish Post,_posts/2020-10-22-because-of-the-internet.md
-
+2020-11-22T10:00:00+00:00,Publish Post,_posts/2020-11-22-the-history-of-marketing.md
 ```
 </comp.CodeBlock>
 
-These values are used to schedule a build and generate the management UI.
-
 ### Generating the schedule
-For convenience, it's likely you'll want to generate `_schedule.txt`.
+For convenience, it's likely you'll want to generate `_schedule.txt` programmatically.
 
 
 


### PR DESCRIPTION
Added a little bit of explanatory text about the 3 different parts of a build scheduled with `_schedule.txt`.