### PR TITLE
Add a note about what time input you might see

### DIFF
--- a/articles/using-date-and-time-inputs-to-edit-your-data.mdx
+++ b/articles/using-date-and-time-inputs-to-edit-your-data.mdx
@@ -84,6 +84,10 @@ Time inputs are shown for inputs configured with the type `time`, or for input k
 * `*_time`
 <comp.DocsImage path="ye_olde_images/time.png" alt="Screenshot of time input field" type="screenshot-snippet"/>
 
+<comp.Notice info_type="info">
+  The editing interface shown here is dependent on your browser and device. CloudCannon uses the default interface from your browser for time inputs.
+</comp.Notice>
+
 <comp.MultiCodeBlock language="yaml" translate_into={["json", "toml"]} source="Naming convention">
 ```
 opening_time: 8:00 am


### PR DESCRIPTION
The appearance/behaviour of the "time" editing interface can differ between browsers and devices. We could add a little note to the docs about this, to minimise any confusion about this.