### PR TITLE
Add baseurl to CloudCannon config

### DIFF
--- a/cloudcannon.config.cjs
+++ b/cloudcannon.config.cjs
@@ -108,5 +108,6 @@ module.exports = {
     commit_templates: [
         {template_string: '{message}'}
     ],
-    timezone: 'Pacific/Auckland'
+    timezone: 'Pacific/Auckland',
+    base_url: 'documentation'
 }


### PR DESCRIPTION
Currently our preview URLs + Visual Editor in CloudCannon are broken because the config is missing a baseurl. I think this should fix it.