### PR TITLE
Update Next.js starter guide with up-to-date build information

### DIFF
--- a/cloudcannon.config.cjs
+++ b/cloudcannon.config.cjs
@@ -33,7 +33,7 @@ module.exports = {
             path: 'guides',
             output: true,
             icon: 'school',
-            url: '/guides/relative_base_path/[slug]/',
+            url: '/guides/[relative_base_path]/[slug]/',
             parser: 'front-matter'
         },
         changelog: {

--- a/guides/nextjs-starter-guide/building.mdx
+++ b/guides/nextjs-starter-guide/building.mdx
@@ -26,11 +26,13 @@ The important things to configure here are:
 * Output Path: Path to the output folder you are building into. This is important because CloudCannon needs to know which folder to treat as the static output of your site.
 
 <comp.Notice info_type="important">
-  If you are using Next.js version less than 13.3.0, you should instead add \`next export\` to your build command.
+  CloudCannon needs the build to output files to work correctly.
 
-  For example, your build script may look like this:
+  If you are using Next.js version 13.3.0 and above, you **must** add `output: 'export'` to your `nextjs.config.js` file.
+  Read the [Next.js documentation on Static Exports](https://nextjs.org/docs/app/building-your-application/deploying/static-exports) for more information.
 
-  "build": "next build && next export"
+  For Next.js versions earlier than 13.3.0, you should instead add `next export` to your build command.
+  For example, the build script in your `package.json` could be `next build && next export`.
 </comp.Notice>
 
 <comp.DocsImage path="ye_olde_images/nextjs-starter-guide-2.png" alt={null} type="screenshot" />

--- a/guides/nextjs-starter-guide/building.mdx
+++ b/guides/nextjs-starter-guide/building.mdx
@@ -1,18 +1,19 @@
 ---
 _schema: guide-item
-_uuid: "74de354d-aa3a-44ca-914a-4dbbacedd258"
-_created_at: "2022-02-03 00:32:03 +0000"
-title: "Build your site"
-nav_title: "Build your site"
+_uuid: 74de354d-aa3a-44ca-914a-4dbbacedd258
+_created_at: '2022-02-03 00:32:03 +0000'
+title: Build your site
+nav_title: Build your site
 order: 3
 published: true
-image: "/documentation/static/CloudCannonDocumentationog.jpg"
-description: "This guide will walk through the steps required to get your Next.js site built, editable and live on CloudCannon."
+image: /documentation/static/CloudCannonDocumentationog.jpg
+description: >-
+  This guide will walk through the steps required to get your Next.js site
+  built, editable and live on CloudCannon.
 tags: []
-related_articles: null
-related_links: null
+related_articles:
+related_links:
 ---
-
 The second step for any new site is to get a successful build. This also mirrors your local development environment. On CloudCannon, select Next.js as your SSG — this will set up the defaults for Next.js.
 
 <comp.DocsImage path="ye_olde_images/nextjs-starter-guide-1.png" alt={null} type="screenshot" />
@@ -21,8 +22,16 @@ The important things to configure here are:
 
 * Any required Environment Variables
 * Install Command: Command to install dependencies before build. By default this runs `npm install`. This is run as a line of bash and can be anything you want. A common change here is to use `yarn install` instead.
-* Build Command: Command to build your site. By default this runs `npm run build`. This is similar to the install command. An example of this build is `next build && next export`
+* Build Command: Command to build your site. By default this runs `npm run build`. This is similar to the install command. An example of this build is `next build`
 * Output Path: Path to the output folder you are building into. This is important because CloudCannon needs to know which folder to treat as the static output of your site.
+
+<comp.Notice info_type="important">
+  If you are using Next.js version less than 13.3.0, you should instead add \`next export\` to your build command.
+
+  For example, your build script may look like this:
+
+  "build": "next build && next export"
+</comp.Notice>
 
 <comp.DocsImage path="ye_olde_images/nextjs-starter-guide-2.png" alt={null} type="screenshot" />
 

--- a/guides/nextjs-starter-guide/building.mdx
+++ b/guides/nextjs-starter-guide/building.mdx
@@ -28,7 +28,7 @@ The important things to configure here are:
 <comp.Notice info_type="important">
   Your build needs to output static files in order for CloudCannon to work correctly.
 
-  If you are using Next.js `v13.3.0` and above, you **must** add `output: 'export'` to your `nextjs.config.js` file.
+  If you are using Next.js `v13.3.0` and above, you **must** add `output: 'export'` to your `next.config.js` file.
   Read the [Next.js documentation on Static Exports](https://nextjs.org/docs/app/building-your-application/deploying/static-exports) for more information.
 
   For Next.js versions earlier than `v13.3.0`, you should instead add `next export` to your build command.

--- a/guides/nextjs-starter-guide/building.mdx
+++ b/guides/nextjs-starter-guide/building.mdx
@@ -1,9 +1,9 @@
 ---
 _schema: guide-item
-_uuid: 74de354d-aa3a-44ca-914a-4dbbacedd258
-_created_at: '2022-02-03 00:32:03 +0000'
-title: Build your site
-nav_title: Build your site
+_uuid: "74de354d-aa3a-44ca-914a-4dbbacedd258"
+_created_at: "2022-02-03 00:32:03 +0000"
+title: "Build your site"
+nav_title: "Build your site"
 order: 3
 published: true
 image: /documentation/static/CloudCannonDocumentationog.jpg

--- a/guides/nextjs-starter-guide/building.mdx
+++ b/guides/nextjs-starter-guide/building.mdx
@@ -20,18 +20,18 @@ The second step for any new site is to get a successful build. This also mirrors
 
 The important things to configure here are:
 
-* Any required Environment Variables
+* Any required Environment Variables.
 * Install Command: Command to install dependencies before build. By default this runs `npm install`. This is run as a line of bash and can be anything you want. A common change here is to use `yarn install` instead.
-* Build Command: Command to build your site. By default this runs `npm run build`. This is similar to the install command. An example of this build is `next build`
+* Build Command: Command to build your site. By default this runs `npm run build`. This is similar to the install command. An example of this build is `next build`.
 * Output Path: Path to the output folder you are building into. This is important because CloudCannon needs to know which folder to treat as the static output of your site.
 
 <comp.Notice info_type="important">
-  CloudCannon needs the build to output files to work correctly.
+  Your build needs to output static files in order for CloudCannon to work correctly.
 
-  If you are using Next.js version 13.3.0 and above, you **must** add `output: 'export'` to your `nextjs.config.js` file.
+  If you are using Next.js `v13.3.0` and above, you **must** add `output: 'export'` to your `nextjs.config.js` file.
   Read the [Next.js documentation on Static Exports](https://nextjs.org/docs/app/building-your-application/deploying/static-exports) for more information.
 
-  For Next.js versions earlier than 13.3.0, you should instead add `next export` to your build command.
+  For Next.js versions earlier than `v13.3.0`, you should instead add `next export` to your build command.
   For example, the build script in your `package.json` could be `next build && next export`.
 </comp.Notice>
 


### PR DESCRIPTION
Next.js have deprecated the `next export` build command in favour of a configuration option. This was done in [Next.js v13.3.0](https://github.com/vercel/next.js/releases/tag/v13.3.0).

This PR updates the information in our Next.js guide to reflect this change.