### PR TITLE
Correct cloudflare hostname example

### DIFF
--- a/articles/creating-a-cloudflare-r2-dam.mdx
+++ b/articles/creating-a-cloudflare-r2-dam.mdx
@@ -75,6 +75,6 @@ Fill out the form as follows, then click "Authenticate" to finish.
 * **Name**: This is the name you will see for your DAM in CloudCannon.
 * **Base URL**: the domain name of the custom domain you configured earlier, where all your DAM assets are accessible.
 * **Region**: This can be set to `auto`.
-* **Endpoint**: you can copy the endpoint from your bucket settings, directly below the name of the bucket. It will look something like `https://[your-account-id].r2.cloudstorage.com`, and should not include anything after the ".com".
+* **Endpoint**: you can copy the endpoint from your bucket settings, directly below the name of the bucket. It will look something like `https://[your-account-id].r2.cloudflarestorage.com`, and should not include anything after the ".com".
 * **Access Key**: this is your Cloudflare account ID.
 * **Access Secret**: this is the API token you saved earlier.


### PR DESCRIPTION
As you can see on [the Cloudflare docs](https://developers.cloudflare.com/r2/api/s3/api/), the Cloudflare API endpoint is `r2.cloudflarestorage.com`. 