### PR TITLE
Add info about group documentation

### DIFF
--- a/articles/editing-objects-in-your-data.mdx
+++ b/articles/editing-objects-in-your-data.mdx
@@ -436,18 +436,6 @@ Object inputs have the following options available within `options` inside an `_
     * `url` for the `href` value of the link (String, *required*).
     * `text` for the visible text used in the link (String). Defaults to `Documentation`.
     * `icon` for the icon displayed next to the link. Must be a Material Icon name. Defaults to `auto_stories`.
-
-    ```yaml
-    _inputs:
-      $:
-        type: object
-        options:
-          groups:
-            - documentation:
-                url: 'https://example.com/documentation/'
-                text: Read more about the fields in this group
-                icon: nature_people
-    ```
   </comp.DataReferenceRow>
   <comp.DataReferenceRow label="place_groups_below" type_markdown="boolean">
     Controls which order input groups and ungrouped inputs appear in. Defaults to `false`. Inputs are grouped with the `groups` options.

--- a/articles/editing-objects-in-your-data.mdx
+++ b/articles/editing-objects-in-your-data.mdx
@@ -430,6 +430,25 @@ Object inputs have the following options available within `options` inside an `_
   <comp.DataReferenceRow label="groups[*].inputs" type_markdown="array of string">
     The input keys included in this group. These keys must reference keys within this object input's data. Defaults to `[]`.
   </comp.DataReferenceRow>
+  <comp.DataReferenceRow label="groups[*].documentation" type_markdown="object">
+    Provides a custom link for documentation for editors shown below the heading of the group. Contains the following fields:
+
+    * `url` for the `href` value of the link (String, *required*).
+    * `text` for the visible text used in the link (String). Defaults to `Documentation`.
+    * `icon` for the icon displayed next to the link. Must be a Material Icon name. Defaults to `auto_stories`.
+
+    ```yaml
+    _inputs:
+      $:
+        type: object
+        options:
+          groups:
+            - documentation:
+                url: 'https://example.com/documentation/'
+                text: Read more about the fields in this group
+                icon: nature_people
+    ```
+  </comp.DataReferenceRow>
   <comp.DataReferenceRow label="place_groups_below" type_markdown="boolean">
     Controls which order input groups and ungrouped inputs appear in. Defaults to `false`. Inputs are grouped with the `groups` options.
   </comp.DataReferenceRow>

--- a/changelogs/2023-08-08_site-config-gui.mdx
+++ b/changelogs/2023-08-08_site-config-gui.mdx
@@ -23,3 +23,4 @@ This release makes a number of big improvements to data editing in CloudCannon, 
 * Fixed an error that could occur when editing arrays of dates.
 * Fixed an error preventing API endpoints from being configured correctly for Cloudflare R2 DAMs.
 * Updated dependencies to patch security vulnerabilities.
+* Fixed an issue where git garbage collection could impact large syncs.


### PR DESCRIPTION
There is a `documentation` field on each item of `groups`, which can be used to show a link to some external docs.