### PR TITLE
Better documentation for dam folder option

### DIFF
--- a/articles/creating-a-cloudflare-r2-dam.mdx
+++ b/articles/creating-a-cloudflare-r2-dam.mdx
@@ -78,3 +78,10 @@ Fill out the form as follows, then click "Authenticate" to finish.
 * **Endpoint**: you can copy the endpoint from your bucket settings, directly below the name of the bucket. It will look something like `https://[your-account-id].r2.cloudflarestorage.com`, and should not include anything after the ".com".
 * **Access Key**: this is your Cloudflare account ID.
 * **Access Secret**: this is the API token you saved earlier.
+
+### Extra options
+
+In your site settings, you can click the context menu on your linked DAM and select **Settings** to configure some extra site-level options.
+
+The **Extra Prefix** option prepends a specified string to all asset paths when browsing and uploading assets. This is useful if you want to ensure that your site can only ever touch a specific folder in your DAM.
+

--- a/articles/creating-a-cloudinary-dam.mdx
+++ b/articles/creating-a-cloudinary-dam.mdx
@@ -31,32 +31,25 @@ In the **Username** field, enter your Cloudinary username. This is the email add
 
 Copy the **Cloud Name**, **API Key**, and **API Secret** from your Cloudinary dashboard into the respective fields in CloudCannon.
 
+Under **Advanced options**, the **Asset browser** option determines how your Cloudinary assets are displayed and navigated in CloudCannon. 
+
+* If you *Use Cloudinary widget*, the Cloudinary widget will open. This gives you access to the advanced filtering options that Cloudinary provides. 
+* If you *Use CloudCannon asset browser*, the normal CloudCannon browser will open, populated with your Cloudinary assets. This is useful is you need to restrict the available assets to just the path specified by the **Folder** option described above.
+
 Once you have filled out all the fields, click **Authenticate** to save and close the modal.
 
 If all went well, you should now be authenticated with your Cloudinary DAM. Next, you'll want to connect it to one or more of your sites.
 
 ### Link Cloudinary to your site
 
-There are some extra configuration options to consider before your site is
-linked to Cloudinary.
+In your site settings, you can click the context menu on your linked DAM and select **Settings** to configure some extra site-level options.
 
-**Upload presets** are configured in Cloudinary, and define how new
-assets are saved. Copy the name of an uploads preset from Cloudinary into
-the corresponding form field in CloudCannon to use that preset when a new
-asset is uploaded.  Read more about [upload presets for Cloudinary
-here](https://cloudinary.com/documentation/upload_presets).
+**Upload presets** are configured in Cloudinary, and define how new assets are saved. Copy the name of an uploads preset from Cloudinary into the corresponding form field in CloudCannon to use that preset when a new asset is uploaded.  Read more about [upload presets for Cloudinary here](https://cloudinary.com/documentation/upload_presets).
 
 <comp.Notice info_type="info">
   If the Upload presets field is left blank, you will not be able to upload new assets to Cloudinary from CloudCannon.
 </comp.Notice>
 
-The **Folder** field determines which Cloudinary folder will be
-opened by default, when a user browses existing assets from the DAM. Note
-that this should not begin with a leading slash.
-
-The **Asset browser** option determines how your Cloudinary assets are displayed and navigated in CloudCannon. 
-
-* If you *Use Cloudinary widget*, the Cloudinary widget will open. This gives you access to the advanced filtering options that Cloudinary provides. 
-* If you *Use CloudCannon asset browser*, the normal CloudCannon browser will open, populated with your Cloudinary assets. This is useful is you need to restrict the available assets to just the path specified by the **Folder** option described above.
+The **Folder** field determines which Cloudinary folder will be opened by default when a user browses existing assets from the DAM. Note that this should not begin with a leading slash.
 
 Finally, click **Link DAM** to connect the DAM to your site.

--- a/articles/creating-a-digitalocean-spaces-dam.mdx
+++ b/articles/creating-a-digitalocean-spaces-dam.mdx
@@ -99,3 +99,10 @@ Fill out the form as follows, then click "Authenticate" to finish.
 * **Endpoint**: this is the same as Base URL, but with the bucket name removed from the front (e.g. `https://reg1.digitaloceanspaces.com`)
 * **Access Key**: the key name for the secret you generated earlier.
 * **Access Secret**: the secret token you generated earlier.
+
+### Extra options
+
+In your site settings, you can click the context menu on your linked DAM and select **Settings** to configure some extra site-level options.
+
+The **Extra Prefix** option prepends a specified string to all asset paths when browsing and uploading assets. This is useful if you want to ensure that your site can only ever touch a specific folder in your DAM.
+

--- a/articles/creating-a-google-cloud-storage-dam.mdx
+++ b/articles/creating-a-google-cloud-storage-dam.mdx
@@ -120,3 +120,11 @@ Set *Storage Bucket Name* to the name of your bucket in Google Cloud Storage.
 Set *Credentials* to the contents of your service account's JSON key.
 
 Click **Authenticate**, to save and close the modal, then click **Link DAM**.
+
+
+### Extra options
+
+In your site settings, you can click the context menu on your linked DAM and select **Settings** to configure some extra site-level options.
+
+The **Extra Prefix** option prepends a specified string to all asset paths when browsing and uploading assets. This is useful if you want to ensure that your site can only ever touch a specific folder in your DAM.
+

--- a/articles/creating-an-s3-dam.mdx
+++ b/articles/creating-an-s3-dam.mdx
@@ -146,3 +146,11 @@ Set *S3 Bucket Name* to the name of your bucket in S3.
 Enter your *Access key ID* and *Secret access key* as your *IAM Access Key* and *IAM Access Secret,* respectively. If you closed your AWS console before you could copy these, read [how to create a new access key and secret](#creating-a-new-access-key-and-secret).
 
 Click **Authenticate**, to save and close the modal, then click **Link DAM**.
+
+### Extra options
+
+In your site settings, you can click the context menu on your linked DAM and select **Settings** to configure some extra site-level options.
+
+The **Extra Prefix** option prepends a specified string to all asset paths when browsing and uploading assets. This is useful if you want to ensure that your site can only ever touch a specific folder in your DAM.
+
+


### PR DESCRIPTION
Several DAMs have a `folder` or "Extra prefix" option which can help to constrain a site to a folder within a DAM. This is largely missing from the docs.
