### PR TITLE
Changing the conditions for uploads being locked on a Cloudinary DAM

### DIFF
--- a/articles/creating-a-cloudinary-dam.mdx
+++ b/articles/creating-a-cloudinary-dam.mdx
@@ -44,10 +44,12 @@ If all went well, you should now be authenticated with your Cloudinary DAM. Next
 
 In your site settings, you can click the context menu on your linked DAM and select **Settings** to configure some extra site-level options.
 
+The **Uploads locked** can be used to prevent uploads to your DAM from within CloudCannon.
+
 **Upload presets** are configured in Cloudinary, and define how new assets are saved. Copy the name of an uploads preset from Cloudinary into the corresponding form field in CloudCannon to use that preset when a new asset is uploaded.  Read more about [upload presets for Cloudinary here](https://cloudinary.com/documentation/upload_presets).
 
 <comp.Notice info_type="info">
-  If the Upload presets field is left blank, you will not be able to upload new assets to Cloudinary from CloudCannon.
+  If you are using the CloudCannon asset browser and the Upload presets field is left blank, you will not be able to upload new assets to Cloudinary from CloudCannon.
 </comp.Notice>
 
 The **Folder** field determines which Cloudinary folder will be opened by default when a user browses existing assets from the DAM. Note that this should not begin with a leading slash.

--- a/articles/creating-a-cloudinary-dam.mdx
+++ b/articles/creating-a-cloudinary-dam.mdx
@@ -48,10 +48,6 @@ The **Uploads locked** can be used to prevent uploads to your DAM from within Cl
 
 **Upload presets** are configured in Cloudinary, and define how new assets are saved. Copy the name of an uploads preset from Cloudinary into the corresponding form field in CloudCannon to use that preset when a new asset is uploaded.  Read more about [upload presets for Cloudinary here](https://cloudinary.com/documentation/upload_presets).
 
-<comp.Notice info_type="info">
-  If you are using the CloudCannon asset browser and the Upload presets field is left blank, you will not be able to upload new assets to Cloudinary from CloudCannon.
-</comp.Notice>
-
 The **Folder** field determines which Cloudinary folder will be opened by default when a user browses existing assets from the DAM. Note that this should not begin with a leading slash.
 
 Finally, click **Link DAM** to connect the DAM to your site.

--- a/articles/managing-your-connected-dams.mdx
+++ b/articles/managing-your-connected-dams.mdx
@@ -47,8 +47,6 @@ To update the settings for using your DAM, on a site-by-site basis:
 
 You check the **Uploads Locked** option to prevent your editors from uploading assets to the DAM from within the CloudCannon app. This is set per-site.
 
-If you're using a Cloudinary DAM, you can prevent uploads by removing the **Upload Preset** instead.
-
 ### Determine where on the site your DAM can be used
 
 The `allowed_sources` configuration option can allow you to choose which "sources" (i.e. DAMs and site files) are available for different editing interfaces across a single site. To use this, you'll need to set a **Reference Key** in the site-level DAM configuration, which you can then reference in the `allowed_sources` array when configuring your inputs and editable regions.


### PR DESCRIPTION
** Not to be merged until the changes are released to CloudCannon **

In an upcoming release, we're going to support uploads to Cloudinary without needing an "unsigned" upload preset. 

Previously, Cloudinary DAMs with no upload preset were automatically considered to be in an "Uploads Locked" state, but that will no longer be the case. We'll be re-introducing the explicit option to lock uploads for a Cloudinary DAM, instead of doing it implicitly by removing the upload preset.