### PR TITLE
Document option to omit cloudinary params

### DIFF
--- a/articles/creating-a-cloudinary-dam.mdx
+++ b/articles/creating-a-cloudinary-dam.mdx
@@ -44,9 +44,11 @@ If all went well, you should now be authenticated with your Cloudinary DAM. Next
 
 In your site settings, you can click the context menu on your linked DAM and select **Settings** to configure some extra site-level options.
 
-The **Uploads locked** can be used to prevent uploads to your DAM from within CloudCannon.
+The **Uploads locked** checkbox can be used to prevent uploads to your DAM from within CloudCannon.
 
 **Upload presets** are configured in Cloudinary, and define how new assets are saved. Copy the name of an uploads preset from Cloudinary into the corresponding form field in CloudCannon to use that preset when a new asset is uploaded.  Read more about [upload presets for Cloudinary here](https://cloudinary.com/documentation/upload_presets).
+
+The **Omit Cloudinary params** checkbox can be used to omit the optional URL parameters provided by Cloudinary when saving URLs. Normally Cloudinary URLs include parameters in the middle of the URL corresponding to the asset type, delivery type, transformations, and versioning of the delivered asset. If this option is checked, URLs will be saved simply as `https://res.cloudinary.com/<cloud_name>/<public_id>.<extension>`. This may be useful if you want to add these parameters in your SSG's templating.
 
 The **Folder** field determines which Cloudinary folder will be opened by default when a user browses existing assets from the DAM. Note that this should not begin with a leading slash.
 


### PR DESCRIPTION
** Not to be merged until this CloudCannon feature is released **

Soon Cloudinary DAMs will have a site-level option to omit the extra params when saving Cloudinary URLs.