### PR TITLE
Incorrect key in documentation

### DIFF
--- a/articles/how-to-choose-what-input-is-used-in-the-data-editor.mdx
+++ b/articles/how-to-choose-what-input-is-used-in-the-data-editor.mdx
@@ -57,7 +57,7 @@ _inputs:
 ```
 </comp.MultiCodeBlock>
 
-This configuration applies to `date` inputs at the root level of your data only:
+This configuration applies to `title` inputs at the root level of your data only:
 
 <comp.MultiCodeBlock language="yaml" translate_into={["json", "toml"]} source="Input configuration">
 ```


### PR DESCRIPTION
I believe this should be `title`:

![image](https://github.com/CloudCannon/platform-documentation/assets/143426640/9a44e6a6-400e-4f07-b839-c12ad26292f3)
