### PR TITLE
Document new Content-Type header for Azure

### DIFF
--- a/articles/creating-an-azure-dam.mdx
+++ b/articles/creating-an-azure-dam.mdx
@@ -33,6 +33,6 @@ Click **Authenticate**, to save and close the modal, then click **Link DAM**.
 
 You can toggle the option to attach metadata to your files when they are uploaded. This could include the email address of the uploader and the file MIME type.
 By default, the `uploadedBy` metadata option is off for new DAMs. To enable this setting, you may need to update your "Resource sharing (CORS)" settings in Azure. Please ensure that the "Allowed Headers" include `x-ms-meta-uploadedBy`.
-By default, the MIME type metadata option is on for new DAM. To enable this setting, you may need to update your "Resource sharing (CORS)" settings in Azure. Please ensure that the "Allowed Headers" include `X-Ms-Blob-Content-Type`.
+By default, the MIME type metadata option is on for new DAM. To enable this setting, you may need to update your "Resource sharing (CORS)" settings in Azure. Please ensure that the "Allowed Headers" include `x-ms-blob-content-type`.
 To edit these settings, navigate to the _Advanced Options_ section under _Org Settings_ > _Assets_ > _Azure DAM_. Enabling the metadata option will only affect files uploaded after the setting is applied. 
 

--- a/articles/creating-an-azure-dam.mdx
+++ b/articles/creating-an-azure-dam.mdx
@@ -16,6 +16,7 @@ Adding a Digital Asset Manager (DAM) to your site enables you to store your imag
 You will need an Azure account to use Blob Storage.
 
 ### Connecting your DAM to CloudCannon
+
 Open your site settings in CloudCannon. Navigate to *Files* */* *Assets*. Under *Link DAM*, select **New DAM**.
 
 Choose **Azure Blob Storage** as your DAM type and enter a name - this will be used to identify your DAM in CloudCannon.
@@ -30,6 +31,8 @@ Click **Authenticate**, to save and close the modal, then click **Link DAM**.
 
 ### Attach metadata to uploaded files
 
-In the same settings, there is also an option to attach metadata to files when they are uploaded. This option only affects files uploaded after the setting is applied. You can have a file tagged with the email address of the user who uploaded it. This will appear under an `uploadedBy` key in the Azure metadata.
+Under **Advanced Options**, there are options to attach metadata to files when they are uploaded. These options only affect files uploaded after the setting is applied. To enable these behaviour, you may need to update the "Allowed Headers" in your "Resource sharing (CORS)" settings in Azure.
 
-To enable this behaviour, you may need to update the "Allowed Headers" in your "Resource sharing (CORS)" settings in Azure. "Allowed Headers" needs to at least include `x-ms-meta-uploadedBy`.
+You can have a file tagged with the email address of the user who uploaded it. This will appear under an `uploadedBy` key in the Azure metadata. Your Azure CORS "Allowed Headers" needs to include `x-ms-meta-uploadedBy` for this to succeed.
+
+You can optionally attach an extra header X-Ms-Blob-Content-Type to indicate the mime-type of uploaded files to Azure. Check the `X-Ms-Blob-Content-Type` checkbox to enable this. Your Azure CORS "Allowed Headers" needs to include `x-ms-blob-content-type` for this to succeed.

--- a/articles/creating-an-azure-dam.mdx
+++ b/articles/creating-an-azure-dam.mdx
@@ -31,7 +31,10 @@ Click **Authenticate**, to save and close the modal, then click **Link DAM**.
 
 ### Attach metadata to uploaded files
 
-Under **Advanced Options**, there are options to attach metadata to files when they are uploaded. These options only affect files uploaded after the setting is applied. To enable these behaviour, you may need to update the "Allowed Headers" in your "Resource sharing (CORS)" settings in Azure.
+You can toggle the option to attach metadata to your files when they are uploaded. This could include the email address of the uploader and the file MIME type.
+By default, the `uploadedBy` metadata option is off for new DAMs. To enable this setting, you may need to update your "Resource sharing (CORS)" settings in Azure. Please ensure that the "Allowed Headers" include `x-ms-meta-uploadedBy`.
+By default, the MIME type metadata option is on for new DAM. To enable this setting, you may need to update your "Resource sharing (CORS)" settings in Azure. Please ensure that the "Allowed Headers" include `X-Ms-Blob-Content-Type`.
+To edit these settings, navigate to the _Advanced Options_ section under _Org Settings_ > _Assets_ > _Azure DAM_. Enabling the metadata option will only affect files uploaded after the setting is applied. 
 
 You can have a file tagged with the email address of the user who uploaded it. This will appear under an `uploadedBy` key in the Azure metadata. Your Azure CORS "Allowed Headers" needs to include `x-ms-meta-uploadedBy` for this to succeed.
 

--- a/articles/creating-an-azure-dam.mdx
+++ b/articles/creating-an-azure-dam.mdx
@@ -36,6 +36,3 @@ By default, the `uploadedBy` metadata option is off for new DAMs. To enable this
 By default, the MIME type metadata option is on for new DAM. To enable this setting, you may need to update your "Resource sharing (CORS)" settings in Azure. Please ensure that the "Allowed Headers" include `X-Ms-Blob-Content-Type`.
 To edit these settings, navigate to the _Advanced Options_ section under _Org Settings_ > _Assets_ > _Azure DAM_. Enabling the metadata option will only affect files uploaded after the setting is applied. 
 
-You can have a file tagged with the email address of the user who uploaded it. This will appear under an `uploadedBy` key in the Azure metadata. Your Azure CORS "Allowed Headers" needs to include `x-ms-meta-uploadedBy` for this to succeed.
-
-You can optionally attach an extra header X-Ms-Blob-Content-Type to indicate the mime-type of uploaded files to Azure. Check the `X-Ms-Blob-Content-Type` checkbox to enable this. Your Azure CORS "Allowed Headers" needs to include `x-ms-blob-content-type` for this to succeed.


### PR DESCRIPTION
Soon CloudCannon will have an option in the Azure DAM settings to include an extra header in all Azure uploads, indicating the mimetype of the uploaded file(s) (e.g. image/png). This behaviour requires a box to be checked in your CloudCannon DAM settings, and you may need to adjust your Azure CORS settings as well.