### PR TITLE
Document empty_type: array option

### DIFF
--- a/articles/select-and-multiselect-inputs.mdx
+++ b/articles/select-and-multiselect-inputs.mdx
@@ -395,6 +395,7 @@ Select and Multiselect inputs have the following options available:
     Value must be one of the following:
 
     * `string` - an empty value for this input will be stored as "".
+    * `array` - an empty value for this input will be stored as `[]`.
     * `null` - an empty value for this input will be stored as a null value (default). This does not apply to TOML files.
 
     Available for Multiselect and Multichoice inputs.


### PR DESCRIPTION
Seems like this option was never added to the docs 