### PR TITLE
Fix: capitalize 'today' in date formatter

### DIFF
--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -18,7 +18,7 @@ document.querySelectorAll("time[data-relative-date]").forEach((el) => {
   // Only show relative dates for entries less than 5 months old
   if (diffMonths < 5) {
     if (diffDays === 0) {
-      el.textContent = "today";
+      el.textContent = "Today";
     } else if (diffDays === 1) {
       el.textContent = "1 day ago";
     } else if (diffDays < 7) {


### PR DESCRIPTION
It was pointed out when the date formatter renders 'today' in the changelogs, it should probably be capitalized?