### PR TITLE
Fix: lighthouse accessibility fixes

### DIFF
--- a/_components/Layout/Footer.tsx
+++ b/_components/Layout/Footer.tsx
@@ -27,6 +27,15 @@ interface FooterProps {
   helpers: Helpers;
 }
 
+const SOCIAL_LABELS: Record<string, string> = {
+  "github": "GitHub",
+  "linkedin": "LinkedIn",
+  "bluesky": "Bluesky",
+  "youtube": "YouTube",
+  "mastodon": "Mastodon",
+  "x-twitter": "X (formerly Twitter)",
+};
+
 export default function Footer({ footernav, helpers }: FooterProps) {
   const links = footernav?.links || [];
   const informationalLinks = footernav?.informational_links || [];
@@ -132,7 +141,11 @@ export default function Footer({ footernav, helpers }: FooterProps) {
           </div>
           <div className="l-footer__banner--links__socials">
             {socialLinks.map((link, index) => (
-              <a key={index} href={link.href}>
+              <a
+                key={index}
+                href={link.href}
+                aria-label={`CloudCannon on ${SOCIAL_LABELS[link.logo] ?? link.logo}`}
+              >
                 <img
                   src={helpers.icon(`${link.logo}:brands`, "fontawesome")}
                   inline="true"

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -1,6 +1,6 @@
 title: CloudCannon
 subtitle: Documentation
-description:
+description: Documentation for CloudCannon — guides, articles, and reference material for editors, marketers, and developers.
 baseurl: "/documentation"
 url: "https://cloudcannon.com"
 twitter_username: CloudCannon

--- a/_includes/layouts/base.tsx
+++ b/_includes/layouts/base.tsx
@@ -9,6 +9,13 @@ interface FooterNav {
   [key: string]: unknown;
 }
 
+interface Meta {
+  title?: string;
+  subtitle?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
 interface Props {
   content: unknown;
   title?: string;
@@ -21,6 +28,7 @@ interface Props {
   explicit_canonical?: string;
   headingnav?: HeaderNavigation;
   footernav?: FooterNav;
+  meta?: Meta;
   hubspot_id?: string;
   ga_id?: string;
   ga_verify?: string;
@@ -41,13 +49,15 @@ export default function BaseLayout(props: Props, helpers: Helpers) {
     explicit_canonical,
     headingnav,
     footernav,
+    meta,
     hubspot_id,
     ga_id,
     ga_verify,
   } = props;
 
   const pageTitle_ = title || details?.title || "";
-  const pageDescription = description || details?.description || "";
+  const pageDescription = description || details?.description ||
+    meta?.description || "";
   const pageTitle = omit_trailing_title
     ? pageTitle_
     : `${pageTitle_} | CloudCannon Documentation`;

--- a/_includes/layouts/home.tsx
+++ b/_includes/layouts/home.tsx
@@ -122,7 +122,7 @@ export default function HomeLayout(props: Props, helpers: Helpers) {
   );
 
   return (
-    <div id="main-content">
+    <main id="main-content">
       {/* Hero Section with Search */}
       <div className="c-hero">
         <h1 data-editable="text" data-prop="hero_title">{hero_title}</h1>
@@ -217,7 +217,7 @@ export default function HomeLayout(props: Props, helpers: Helpers) {
           </div>
         </div>
       )}
-    </div>
+    </main>
   );
 }
 


### PR DESCRIPTION
This PR addresses a number of issues identified by Lighthouse:

- the social icons in the footer were lacking a discernible name, so added `aria-label`
- the site was lacking a meta description for the homepage - was never reading `_data/meta.yml` or front matter, so hooked up the yml file as the final fallback if other page descriptions are missing
- site was lacking a `main` landmark, so change the `div#main-content` to `main#main-content`

Lighthouse scores should be 100 now for accessibility and SEO.

## Cloudvent for testing

https://excited-charger.cloudvent.net/documentation