### PR TITLE
Add page title and guide title to SEO title fields for guides

### DIFF
--- a/_includes/layouts/base.tsx
+++ b/_includes/layouts/base.tsx
@@ -21,6 +21,7 @@ interface Props {
   explicit_canonical?: string;
   headingnav?: HeaderNavigation;
   footernav?: FooterNav;
+  guide_title?: string;
   hubspot_id?: string;
   ga_id?: string;
   ga_verify?: string;
@@ -41,12 +42,16 @@ export default function BaseLayout(props: Props, helpers: Helpers) {
     explicit_canonical,
     headingnav,
     footernav,
+    guide_title,
     hubspot_id,
     ga_id,
     ga_verify,
   } = props;
 
-  const pageTitle_ = title || details?.title || "";
+  const pageTitle_ = title ||
+    (guide_title && details?.title
+      ? `${details.title} — ${guide_title}`
+      : details?.title) || "";
   const pageDescription = description || details?.description || "";
   const pageTitle = omit_trailing_title
     ? pageTitle_


### PR DESCRIPTION
It was noted that searching for guides in Google shows only the page title, e.g. "Introduction" for the first page in a guide. Hard to know if this is the correct result without guide title included as well.

This PR adds `guide_title` into the title fields for guides only.

Order is hierarchical - `[page_title] - [guide_title]`. Rationale for this:

- makes scanning SERP results easier than if `[guide_title]` appeared first
- truncated results mean putting long `[guide_title]` first might remove the page-specific info altogether from the search results
- standard practice as docs sites generally lead with page title first, e.g. MDN docs