### PR TITLE
Fix typo CloudCanon -> CloudCannon

### DIFF
--- a/changelogs/2026/02-11_improved-schema-reliability.mdx
+++ b/changelogs/2026/02-11_improved-schema-reliability.mdx
@@ -14,7 +14,7 @@ It also addressed several issues, including those affecting Hugo shortcodes, fil
 
 ## Fixes
 
-* Fixed an issue where CloudCanon would fail to load *Schema* files and *Default content* files with Markdown extensions (`.md`) if the front matter block was missing its closing `---` fence. CloudCannon now falls back to parsing the file content as YAML in this case.
+* Fixed an issue where CloudCannon would fail to load *Schema* files and *Default content* files with Markdown extensions (`.md`) if the front matter block was missing its closing `---` fence. CloudCannon now falls back to parsing the file content as YAML in this case.
 * Fixed an issue where, in some cases, creating multiple files from the same *Schema* could result in duplicated or incorrect front matter data. This issue also affected body content in data file *Schemas* (`.json`, `.yml`, `.yaml`, `.toml`).
 * Fixed an issue where, in some cases, CloudCannon would incorrectly apply  YAML front matter indentation when creating new files from a *Schema*.
 * Fixed an issue where CloudCannon would incorrectly save unknown Hugo shortcodes when the shortcode name contains a `/` character.


### PR DESCRIPTION
Just a typo. `CloudCanon` instead of `CloudCannon`.