### PR TITLE
Fix: form ajax request status should be 200

### DIFF
--- a/developer/articles/connecting-your-site-to-an-inbox.mdx
+++ b/developer/articles/connecting-your-site-to-an-inbox.mdx
@@ -139,7 +139,7 @@ formEl.addEventListener("submit", function (e) {
   var request = new XMLHttpRequest();
 
   request.addEventListener("load", function () {
-    if (request.status === 303) { // CloudCannon redirects on success
+    if (request.status === 200) {
       // It worked
     }
   });

--- a/developer/articles/creating-a-form-for-your-site-on-cloudcannon.mdx
+++ b/developer/articles/creating-a-form-for-your-site-on-cloudcannon.mdx
@@ -142,7 +142,7 @@ formEl.addEventListener("submit", function (e) {
   var request = new XMLHttpRequest();
 
   request.addEventListener("load", function () {
-    if (request.status === 303) { // CloudCannon redirects on success
+    if (request.status === 200) {
       // It worked
     }
   });


### PR DESCRIPTION
Might need to check the actual app - maybe the return status code _is_ meant to be `303`?

However, currently:

- set up inbox
- copy code example from CloudCannon docs
- `console.log` `request.status` in the `load` callback
- see `200`

Can confirm the submissions were successful, so this does seem to be the current status code returned.