### PR TITLE
Fix: hide the 'Examples' heading if no examples

### DIFF
--- a/_components/Reference/ReferenceContent.tsx
+++ b/_components/Reference/ReferenceContent.tsx
@@ -233,8 +233,7 @@ export default function ReferenceContent({
           withIds
           slugify={slugify}
         />
-
-        {showExamples && (
+        {showExamples && examples.length > 0 && (
           <>
             <dt id="examples">Examples:</dt>
             {examples.map((example, i) => (


### PR DESCRIPTION
Developer Reference pages show `Examples:` at the bottom, regardless of whether the entry has any examples or not.

<img width="756" height="480" alt="Screenshot 2026-07-28 at 3 07 20 PM" src="https://github.com/user-attachments/assets/0df64047-29ee-48cd-9b20-a0ca5f07055c" />

&nbsp;

There is a prop in `ReferenceContent.tsx` that sets `showExamples` to `true` by default, but this prop is never actually passed in when the component is used:

```
<comp.Reference.ReferenceContent
  entry={entry}
  currentUrl={currentUrl}
  section={section}
  helpers={helpers}
/>
```

Thus, `showExamples` is always `true`. It was unclear how/where this prop was intended to be set (automatically based on whether there were examples present, or set by editor, etc) so I have simply added a check to hide the heading if `examples.length` is not greater than 0. Can be updated in the future if we want finer control over hiding/showing examples.

<img width="741" height="532" alt="Screenshot 2026-07-28 at 3 07 36 PM" src="https://github.com/user-attachments/assets/e7e0eb83-28a3-4e26-a065-22aa49b3288d" />
