### PR TITLE
Fix: make the links in the changelog blue

### DIFF
--- a/_includes/styles/layout.scss
+++ b/_includes/styles/layout.scss
@@ -230,7 +230,7 @@ body:has(dialog[open]) {
 }
 
 .changelog-entry {
-  & a:not(.c-anchor-header__link) {
+  & :is(h1, h2, h3, h4, h5, h6) > a:not(.c-anchor-header__link) {
     color: var(--text);
   }
 


### PR DESCRIPTION
Links in the changelog content are white, but should be the same blue as the rest of the site.

Before:
<img width="741" height="575" alt="Screenshot 2026-07-29 at 10 35 46 AM" src="https://github.com/user-attachments/assets/631c51c6-59c8-4efe-a354-c3cb4e476cb6" />


After:
<img width="769" height="582" alt="Screenshot 2026-07-29 at 10 35 56 AM" src="https://github.com/user-attachments/assets/3863d5dd-46dd-468e-ad14-eb4a30dbd28b" />
