### PR TITLE
Refactor/pagefind UI changes

### DIFF
--- a/_components/Layout/InlineSearch.tsx
+++ b/_components/Layout/InlineSearch.tsx
@@ -23,6 +23,49 @@ export default function InlineSearch({
         placeholder={placeholder}
         {...(autofocus ? { autofocus: true } : {})}
       ></pagefind-input>
+      <div
+        className="cc-search-recents"
+        x-data="searchRecents"
+        x-show="$store.search.hasFocus && !$store.search.hasQuery && $store.search.recents.length"
+        x-cloak
+      >
+        <h3 className="cc-search-recents__title">Recent searches</h3>
+        <ul className="cc-search-recents__list">
+          <template x-for="term in $store.search.recents" x-bind:key="term">
+            <li className="cc-search-recents__item">
+              <button
+                type="button"
+                className="cc-search-recents__button"
+                {...{
+                  "x-on:click.stop.prevent": "triggerRecent(term)",
+                  "x-on:mousedown.prevent": "void 0",
+                }}
+                x-bind:title="`Search for ${term}`"
+              >
+                <span className="cc-search-recents__icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+                    <path d="M13 3a9 9 0 1 0 9 9h-2a7 7 0 1 1-7-7V3zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z" />
+                  </svg>
+                </span>
+                <span x-text="term"></span>
+              </button>
+              <button
+                type="button"
+                className="cc-search-recents__remove"
+                {...{
+                  "x-on:click.stop.prevent": "removeRecent(term)",
+                  "x-on:mousedown.prevent": "void 0",
+                }}
+                aria-label="Remove from recent searches"
+              >
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+                  <path d="M18.3 5.71L12 12l6.3 6.29-1.42 1.42L10.59 13.4l-6.3 6.3-1.41-1.42L9.17 12l-6.3-6.29 1.42-1.42 6.3 6.3 6.29-6.3z" />
+                </svg>
+              </button>
+            </li>
+          </template>
+        </ul>
+      </div>
       <comp.Layout.SearchResults />
     </div>
   );

--- a/_components/Layout/Search.tsx
+++ b/_components/Layout/Search.tsx
@@ -11,6 +11,49 @@ export default function Search({ comp }: { comp: Comp }) {
           <pagefind-input></pagefind-input>
         </pagefind-modal-header>
         <pagefind-modal-body>
+          <div
+            className="cc-search-recents"
+            x-data="searchRecents"
+            x-show="$store.search.hasFocus && !$store.search.hasQuery && $store.search.recents.length"
+            x-cloak
+          >
+            <h3 className="cc-search-recents__title">Recent searches</h3>
+            <ul className="cc-search-recents__list">
+              <template x-for="term in $store.search.recents" x-bind:key="term">
+                <li className="cc-search-recents__item">
+                  <button
+                    type="button"
+                    className="cc-search-recents__button"
+                    {...{
+                      "x-on:click.stop.prevent": "triggerRecent(term)",
+                      "x-on:mousedown.prevent": "void 0",
+                    }}
+                    x-bind:title="`Search for ${term}`"
+                  >
+                    <span className="cc-search-recents__icon" aria-hidden="true">
+                      <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+                        <path d="M13 3a9 9 0 1 0 9 9h-2a7 7 0 1 1-7-7V3zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z" />
+                      </svg>
+                    </span>
+                    <span x-text="term"></span>
+                  </button>
+                  <button
+                    type="button"
+                    className="cc-search-recents__remove"
+                    {...{
+                      "x-on:click.stop.prevent": "removeRecent(term)",
+                      "x-on:mousedown.prevent": "void 0",
+                    }}
+                    aria-label="Remove from recent searches"
+                  >
+                    <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+                      <path d="M18.3 5.71L12 12l6.3 6.29-1.42 1.42L10.59 13.4l-6.3 6.3-1.41-1.42L9.17 12l-6.3-6.29 1.42-1.42 6.3 6.3 6.29-6.3z" />
+                    </svg>
+                  </button>
+                </li>
+              </template>
+            </ul>
+          </div>
           <comp.Layout.SearchResults />
         </pagefind-modal-body>
         <pagefind-modal-footer>

--- a/_components/Layout/SearchResults.tsx
+++ b/_components/Layout/SearchResults.tsx
@@ -40,7 +40,14 @@ const SearchResultTemplate = `
 export default function SearchResults() {
   return (
     <div className="t-searcher-layout">
-      <pagefind-filter-pane filter="site" label="Filters" expanded></pagefind-filter-pane>
+      <pagefind-filter-pane
+        filter="site"
+        label="Filters"
+        expanded
+        x-data
+        x-show="$store.search.hasQuery"
+        x-cloak
+      ></pagefind-filter-pane>
       <div className="t-searcher-results">
         <pagefind-summary></pagefind-summary>
         <pagefind-results>

--- a/_components/Layout/SearchResults.tsx
+++ b/_components/Layout/SearchResults.tsx
@@ -60,7 +60,8 @@ export default function SearchResults() {
           x-bind:aria-pressed="!selected"
           x-on:click="setFilter('')"
         >
-          All
+          <span>All</span>
+          <span className="cc-search-pills__count" x-text="totalCount()"></span>
         </button>
         <template x-for="[value, count] in entries()" x-bind:key="value">
           <button

--- a/_components/Layout/SearchResults.tsx
+++ b/_components/Layout/SearchResults.tsx
@@ -39,17 +39,55 @@ const SearchResultTemplate = `
 
 export default function SearchResults() {
   return (
-    <div className="t-searcher-layout">
-      <pagefind-filter-pane
-        filter="site"
-        label="Filters"
-        expanded
-        x-data
-        x-show="$store.search.hasQuery"
+    <div
+      className="t-searcher-layout"
+      x-data
+      x-show="$store.search.hasQuery"
+      x-cloak
+    >
+      <div
+        className="cc-search-pills"
+        x-data="searchPills"
+        x-show="entries().length"
         x-cloak
-      ></pagefind-filter-pane>
+        role="radiogroup"
+        aria-label="Filter by section"
+      >
+        <button
+          type="button"
+          className="cc-search-pills__pill"
+          x-bind:class="{ 'cc-search-pills__pill--active': !selected }"
+          x-bind:aria-pressed="!selected"
+          x-on:click="setFilter('')"
+        >
+          All
+        </button>
+        <template x-for="[value, count] in entries()" x-bind:key="value">
+          <button
+            type="button"
+            className="cc-search-pills__pill"
+            x-bind:class="{ 'cc-search-pills__pill--active': selected === value }"
+            x-bind:aria-pressed="selected === value"
+            x-on:click="setFilter(value)"
+          >
+            <span x-text="value"></span>
+            <span className="cc-search-pills__count" x-text="count"></span>
+          </button>
+        </template>
+      </div>
       <div className="t-searcher-results">
-        <pagefind-summary></pagefind-summary>
+        <div className="cc-search-summary">
+          <pagefind-summary></pagefind-summary>
+          <span
+            className="cc-search-summary__scope"
+            x-data
+            x-show="$store.search.hasQuery && $store.search.selectedFilter"
+            x-cloak
+          >
+            {" in "}
+            <strong x-text="$store.search.selectedFilter"></strong>
+          </span>
+        </div>
         <pagefind-results>
           <script type="text/pagefind-template" dangerouslySetInnerHTML={{ __html: SearchResultTemplate }} />
         </pagefind-results>

--- a/_includes/scripts/alpine.js
+++ b/_includes/scripts/alpine.js
@@ -318,6 +318,7 @@ function writeRecents(recents) {
 Alpine.store("search", {
   hasQuery: false,
   hasFocus: false,
+  selectedFilter: "",
   recents: readRecents(),
 });
 
@@ -346,10 +347,14 @@ function setupPagefindInstance(attempt = 0) {
     return;
   }
   globalThis.searchInstance = instance;
-  instance.on("search", (term) => {
+  // Default filter — start focused on Articles.
+  instance.triggerFilters?.({ site: ["Articles"] });
+  instance.on("search", (term, filters) => {
     const trimmed = typeof term === "string" ? term.trim() : "";
     const store = Alpine.store("search");
     store.hasQuery = trimmed.length > 0;
+    const sel = filters?.site;
+    store.selectedFilter = Array.isArray(sel) && sel.length ? sel[0] : "";
     if (trimmed.length > 0) {
       const next = [
         trimmed,
@@ -363,6 +368,49 @@ function setupPagefindInstance(attempt = 0) {
   });
 }
 setupPagefindInstance();
+
+Alpine.data("searchPills", () => ({
+  filters: {},
+  selected: "",
+  init() {
+    const wait = (attempt = 0) => {
+      const inst = globalThis.searchInstance;
+      if (!inst) {
+        if (attempt < 50) setTimeout(() => wait(attempt + 1), 100);
+        return;
+      }
+      inst.on("filters", (data) => {
+        // Prefer `total` — counts per category ignoring the currently applied
+        // site filter, so switching pills reflects what results you'd get.
+        // Fall back to `available` if `total` isn't populated for this index.
+        this.filters = data?.total?.site || data?.available?.site || {};
+      });
+      inst.on("search", (_term, filters) => {
+        const sel = filters?.site;
+        this.selected = Array.isArray(sel) && sel.length ? sel[0] : "";
+      });
+    };
+    wait();
+  },
+  entries() {
+    const preferred = ["Articles", "Guides", "Reference", "Changelog"];
+    const all = Object.entries(this.filters || {});
+    return all.sort((a, b) => {
+      const ai = preferred.indexOf(a[0]);
+      const bi = preferred.indexOf(b[0]);
+      if (ai === -1 && bi === -1) return a[0].localeCompare(b[0]);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+  },
+  setFilter(value) {
+    const inst = globalThis.searchInstance;
+    if (!inst?.triggerFilter) return;
+    this.selected = value;
+    inst.triggerFilter("site", value ? [value] : []);
+  },
+}));
 
 Alpine.data("searchRecents", () => ({
   triggerRecent(term) {

--- a/_includes/scripts/alpine.js
+++ b/_includes/scripts/alpine.js
@@ -347,8 +347,6 @@ function setupPagefindInstance(attempt = 0) {
     return;
   }
   globalThis.searchInstance = instance;
-  // Default filter — start focused on Articles.
-  instance.triggerFilters?.({ site: ["Articles"] });
   instance.on("search", (term, filters) => {
     const trimmed = typeof term === "string" ? term.trim() : "";
     const store = Alpine.store("search");
@@ -403,6 +401,9 @@ Alpine.data("searchPills", () => ({
       if (bi === -1) return -1;
       return ai - bi;
     });
+  },
+  totalCount() {
+    return Object.values(this.filters || {}).reduce((s, v) => s + (v || 0), 0);
   },
   setFilter(value) {
     const inst = globalThis.searchInstance;

--- a/_includes/scripts/alpine.js
+++ b/_includes/scripts/alpine.js
@@ -296,6 +296,101 @@ document.addEventListener("toggle", (e) => {
   }
 }, true); // Use capture phase since toggle doesn't bubble
 
+const RECENTS_KEY = "docs-pagefind-recents";
+const RECENTS_MAX = 5;
+
+function readRecents() {
+  try {
+    return JSON.parse(localStorage.getItem(RECENTS_KEY)) ?? [];
+  } catch {
+    return [];
+  }
+}
+
+function writeRecents(recents) {
+  try {
+    localStorage.setItem(RECENTS_KEY, JSON.stringify(recents));
+  } catch {
+    // Ignore quota / private mode errors.
+  }
+}
+
+Alpine.store("search", {
+  hasQuery: false,
+  hasFocus: false,
+  recents: readRecents(),
+});
+
+function isPagefindInputFocused() {
+  const active = document.activeElement;
+  return !!active && typeof active.closest === "function" &&
+    active.closest("pagefind-input") !== null;
+}
+
+function refreshSearchFocus() {
+  const store = Alpine.store("search");
+  const now = isPagefindInputFocused();
+  if (store.hasFocus !== now) store.hasFocus = now;
+}
+
+document.addEventListener("focusin", refreshSearchFocus);
+document.addEventListener("focusout", () => {
+  requestAnimationFrame(refreshSearchFocus);
+});
+
+function setupPagefindInstance(attempt = 0) {
+  const im = globalThis.PagefindComponents?.getInstanceManager?.();
+  const instance = im?.getInstance?.("default");
+  if (!instance) {
+    if (attempt < 50) setTimeout(() => setupPagefindInstance(attempt + 1), 100);
+    return;
+  }
+  globalThis.searchInstance = instance;
+  instance.on("search", (term) => {
+    const trimmed = typeof term === "string" ? term.trim() : "";
+    const store = Alpine.store("search");
+    store.hasQuery = trimmed.length > 0;
+    if (trimmed.length > 0) {
+      const next = [
+        trimmed,
+        ...store.recents.filter((r) => r !== trimmed),
+      ].slice(0, RECENTS_MAX);
+      store.recents = next;
+      writeRecents(next);
+    } else {
+      store.recents = readRecents();
+    }
+  });
+}
+setupPagefindInstance();
+
+Alpine.data("searchRecents", () => ({
+  triggerRecent(term) {
+    // Find the pagefind-input that shares an ancestor with this recents block
+    // (so the modal's recents drive the modal's input, and the inline recents
+    // drive the inline input). Fall back to the first one in the document,
+    // then to triggerSearch as a last resort.
+    let inputEl = null;
+    let ancestor = this.$root;
+    while (ancestor && !inputEl) {
+      inputEl = ancestor.querySelector?.("pagefind-input input");
+      ancestor = ancestor.parentElement;
+    }
+    if (!inputEl) inputEl = document.querySelector("pagefind-input input");
+    if (inputEl) {
+      inputEl.value = term;
+      inputEl.dispatchEvent(new Event("input", { bubbles: true }));
+      return;
+    }
+    globalThis.searchInstance?.triggerSearch?.(term);
+  },
+  removeRecent(term) {
+    const store = Alpine.store("search");
+    store.recents = store.recents.filter((r) => r !== term);
+    writeRecents(store.recents);
+  },
+}));
+
 Alpine.magic("getRecentSearches", () => {
   return () => {
     try {

--- a/_includes/styles/search.scss
+++ b/_includes/styles/search.scss
@@ -1783,3 +1783,94 @@ pagefind-modal-footer {
 pagefind-modal-header {
   border-bottom: 0;
 }
+
+.cc-search-recents {
+  padding: 16px 20px 8px;
+
+  &[x-cloak] {
+    display: none !important;
+  }
+
+  &__title {
+    margin: 0 0 8px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    color: var(--pf-text-muted);
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    border-radius: var(--pf-border-radius);
+
+    &:hover {
+      background: var(--pf-hover);
+    }
+  }
+
+  &__button {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background: none;
+    border: 0;
+    cursor: pointer;
+    text-align: start;
+    font: inherit;
+    color: var(--pf-text-secondary);
+    min-width: 0;
+
+    &:hover {
+      color: var(--pf-text);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--selected-blue);
+      outline-offset: -2px;
+    }
+  }
+
+  &__icon {
+    display: inline-flex;
+    align-items: center;
+    color: var(--pf-text-muted);
+    flex-shrink: 0;
+  }
+
+  &__remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    margin-right: 6px;
+    background: none;
+    border: 0;
+    border-radius: var(--pf-border-radius);
+    cursor: pointer;
+    color: var(--pf-text-muted);
+
+    &:hover {
+      color: var(--pf-text);
+      background: var(--pf-skeleton);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--selected-blue);
+      outline-offset: -2px;
+    }
+  }
+}

--- a/_includes/styles/search.scss
+++ b/_includes/styles/search.scss
@@ -1656,14 +1656,6 @@ pagefind-modal-trigger {
   margin: 30px auto 0;
   padding: 0 16px;
 
-  .t-searcher-layout {
-    display: none;
-
-    &:has(.pf-results:not(:empty)) {
-      display: flex;
-    }
-  }
-
   // Main results area
   .t-inline-search__main {
     display: flex;
@@ -1782,6 +1774,95 @@ pagefind-modal-footer {
 
 pagefind-modal-header {
   border-bottom: 0;
+}
+
+.cc-search-summary {
+  font-size: var(--pf-summary-font-size);
+  color: var(--pf-text-muted);
+  line-height: 1.4;
+  padding: 12px 0 8px;
+
+  pagefind-summary {
+    display: inline !important;
+  }
+
+  .pf-summary {
+    display: inline !important;
+    margin: 0 !important;
+  }
+
+  &__scope {
+    color: inherit;
+    font-size: inherit;
+
+    &[x-cloak] {
+      display: none !important;
+    }
+
+    strong {
+      font-weight: 600;
+      color: var(--pf-text);
+    }
+  }
+}
+
+.cc-search-pills {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 20px 16px 12px 0;
+
+  &[x-cloak] {
+    display: none !important;
+  }
+
+  &__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 999px;
+    border: 1px solid var(--button-border);
+    background: transparent;
+    color: var(--pf-text-secondary);
+    font: inherit;
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    white-space: nowrap;
+
+    &:hover {
+      border-color: var(--selected-blue);
+      color: var(--pf-text);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--selected-blue);
+      outline-offset: 2px;
+    }
+
+    &--active {
+      background: var(--selected-blue);
+      border-color: var(--selected-blue);
+      color: white;
+
+      &:hover {
+        color: white;
+      }
+    }
+  }
+
+  &__count {
+    font-size: 12px;
+    color: var(--pf-text-muted);
+    font-variant-numeric: tabular-nums;
+
+    .cc-search-pills__pill--active & {
+      color: white;
+    }
+  }
 }
 
 .cc-search-recents {


### PR DESCRIPTION
This PR addresses a number of issues with the pagefind interface on the CloudCannon Docs site.

- a 'recent search' history added - a requested feature, and also mimics the functionality of the main CloudCannon marketing site - shows on focus
<img width="965" height="278" alt="Screenshot 2026-07-29 at 3 10 36 PM" src="https://github.com/user-attachments/assets/6d8da878-ff17-42b1-b7ab-d6ed81cf6d58" />

- styled the category filters: 
  - first, the checkboxes were probably the incorrect UI element, as the functionality was closer aligned to a radio input - actually, could mess up the search entirely if multiple checkboxes ended up being checked
  - second, hid the filters until a search is performed - as above, showing them from the beginning allowed users to check multiple, after which performing a search wouldn't work at all
  - third, the pills align better to the CloudCannon marketing site style
  - fourth, reordered the filters to deprioritise changelogs from the search
<img width="976" height="387" alt="Screenshot 2026-07-29 at 3 10 52 PM" src="https://github.com/user-attachments/assets/fbb9131e-ea7d-43c8-b329-1e3cc56885f7" />

- finally, standardised some inconsistencies between the main search box on the homepage and the search modal - e.g. missing feedback on the homepage search box if search returns no results
<img width="965" height="319" alt="Screenshot 2026-07-29 at 3 11 24 PM" src="https://github.com/user-attachments/assets/d613d000-c9cb-46bb-9ae5-27a6d6c4d9e3" />

## Cloudvent for testing

https://purple-rope.cloudvent.net/documentation/