### PR TITLE
Wrap category pills on mobile instead of stacking vertically

### DIFF
--- a/_includes/styles/search.scss
+++ b/_includes/styles/search.scss
@@ -1813,6 +1813,13 @@ pagefind-modal-header {
   gap: 10px;
   padding: 20px 16px 12px 0;
 
+  @media (max-width: 800px) {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 0 4px;
+  }
+
   &[x-cloak] {
     display: none !important;
   }


### PR DESCRIPTION
New category pills stack vertically on mobile, which isn't ideal:
<img width="486" height="625" alt="Screenshot 2026-07-30 at 9 54 37 AM" src="https://github.com/user-attachments/assets/c17d1057-d27b-4d20-ba87-f9ca4a023b5f" />

This PR has them wrap as needed:
<img width="459" height="516" alt="Screenshot 2026-07-30 at 9 53 48 AM" src="https://github.com/user-attachments/assets/94851405-1813-45b4-89ab-fb0107b2ac92" />
