### PR TITLE
Fix: incorrect position for final annotation in a codeblock

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -381,35 +381,42 @@ const annotateCodeBlocks = (page: Lume.Page): void => {
             }
             next_el = next_el.nextSibling;
           }
-          let insert_before_el: ChildNode | null = next_newline || token;
+          if (next_newline) {
+            let insert_before_el: ChildNode | null = next_newline;
 
-          // Text nodes might span multiple lines, so we split it on newlines
-          // and re-add each as independent text nodes, so that we can add an element before
-          // the newline.
-          const insertNodeValue = (insert_before_el as Text)?.nodeValue;
-          if (insertNodeValue && /\n/.test(insertNodeValue)) {
-            const chunks = insertNodeValue
-              .split("\n")
-              .map((chunk: string) => page.document!.createTextNode(chunk));
-            for (let i = 0; i < chunks.length; i += 1) {
-              insert_before_el?.parentNode?.insertBefore(
-                chunks[i],
-                insert_before_el,
-              );
-              if (i !== chunks.length - 1) {
+            // Text nodes might span multiple lines, so we split it on newlines
+            // and re-add each as independent text nodes, so that we can add an element before
+            // the newline.
+            const insertNodeValue = (insert_before_el as Text)?.nodeValue;
+            if (insertNodeValue && /\n/.test(insertNodeValue)) {
+              const chunks = insertNodeValue
+                .split("\n")
+                .map((chunk: string) => page.document!.createTextNode(chunk));
+              for (let i = 0; i < chunks.length; i += 1) {
                 insert_before_el?.parentNode?.insertBefore(
-                  page.document!.createTextNode("\n"),
+                  chunks[i],
                   insert_before_el,
                 );
+                if (i !== chunks.length - 1) {
+                  insert_before_el?.parentNode?.insertBefore(
+                    page.document!.createTextNode("\n"),
+                    insert_before_el,
+                  );
+                }
               }
+              insert_before_el?.remove();
+              insert_before_el = chunks[0].nextSibling;
             }
-            insert_before_el?.remove();
-            insert_before_el = chunks[0].nextSibling;
+            insert_before_el?.parentNode?.insertBefore(
+              commentEl,
+              insert_before_el,
+            );
+          } else {
+            // No newline found ahead — this marker is on the last line of the
+            // code block (which has been trimmed of its trailing newline).
+            // Append the badge as the last child so it lands at end-of-line.
+            codeEl.appendChild(commentEl);
           }
-          insert_before_el?.parentNode?.insertBefore(
-            commentEl,
-            insert_before_el,
-          );
         }
 
         if (is_text) {


### PR DESCRIPTION
The last annotation in an annotated code block would position at the _start_ of the line instead of at the _end_.

<img width="727" height="298" alt="Screenshot 2026-07-30 at 10 56 39 AM" src="https://github.com/user-attachments/assets/e3ae64cd-b560-4e86-80be-eeebac38fe49" />

This was caused by the code attempting to find a newline marker to insert next to. The last line of code had no newline at the end, so the code ended up adding the annotation at the start.

This PR fixes that behaviour.

<img width="714" height="289" alt="Screenshot 2026-07-30 at 10 56 45 AM" src="https://github.com/user-attachments/assets/b21479d1-2dae-4422-b882-fa1c484fbc5b" />
