### PR TITLE
Fix: developer reference landing page TOC missing on mobile

### DIFF
--- a/_includes/layouts/reference-home.tsx
+++ b/_includes/layouts/reference-home.tsx
@@ -109,9 +109,7 @@ export default function ReferenceHomeLayout(
           <div className="l-copy-page-mobile" data-pagefind-ignore>
             <comp.CopyPageDropdown title={details?.title || ""} url={currentUrl} helpers={helpers} />
           </div>
-          <comp.Layout.MobileTOC helpers={helpers} listClassName="">
-            <comp.Reference.TableOfContents entry={derivedRootEntry} section={section} />
-          </comp.Layout.MobileTOC>
+          <comp.Layout.MobileTOC helpers={helpers} />
 
           <div className="l-content-split">
             <main id="main-content">


### PR DESCRIPTION
The TOC was missing on mobile for the Developer Reference landing page. 
<img width="466" height="268" alt="Screenshot 2026-07-30 at 11 26 29 AM" src="https://github.com/user-attachments/assets/739f5bae-8dec-4870-8c41-a72bd2640ba1" />


This is because it was set up to auto-populate with the reference items (like subpages) - however, it didn't get its items from the configuration-types data, but rather is a content page more like the other pages on the site.

Code already set up to auto-populate TOC based on `h2` on the page, so removed the 'reference-specific' elements, and let it just fallback to being a regular TOC.
<img width="431" height="386" alt="Screenshot 2026-07-30 at 11 26 14 AM" src="https://github.com/user-attachments/assets/978afa8b-b737-48af-96cd-1ca5364ddd81" />
