### PR TITLE
Fix: mobile menu height

### DIFF
--- a/_includes/styles/nav.scss
+++ b/_includes/styles/nav.scss
@@ -348,7 +348,7 @@
       left: 0;
       background: var(--background);
       width: 100%;
-      height: 100vh;
+      height: 100dvh;
       padding: 0; // No padding - banner is full width
       flex-direction: column;
 


### PR DESCRIPTION
Didn't notice during development because it appears 'responsive' mode in dev tools doesn't calculate viewport height in the same way as an actual phone. Mobile menu often not displayed correctly on various devices.

Before (Android vs iPhone):
<img width="300" alt="Screenshot_2026-07-30-15-00-58-08_40deb401b9ffe8e1df2f1cc5ba480b12" src="https://github.com/user-attachments/assets/516e9004-8a4c-4f65-9c31-bbbf8eb7c43e" />
<img width="300" alt="IMG_3657" src="https://github.com/user-attachments/assets/77aac325-5030-4edb-bc1a-f0702268a083" />

This PR changes `100vh` to `100dvh` - previous responsive browser emulation didn't account for actual Chrome/Safari URL bar, instead taking maximum viewport height as the calculation; (dynamic viewport height) adjusts to the current visible viewport as browser chrome slides in/out.

After (Android vs iPhone):
 <img width="300" alt="Screenshot_2026-07-30-15-00-46-57_40deb401b9ffe8e1df2f1cc5ba480b12" src="https://github.com/user-attachments/assets/a0db3b8e-ea21-4c39-8408-e2064a40ec1e" />
<img width="300" alt="IMG_3658" src="https://github.com/user-attachments/assets/9d8b7f74-4459-4ec6-ba16-e09e602677be" />

