### PR TITLE
Fix/italics in changelog titles

### DIFF
--- a/.cloudcannon/collections/changelog.cloudcannon.collections.yml
+++ b/.cloudcannon/collections/changelog.cloudcannon.collections.yml
@@ -18,12 +18,36 @@ changelog:
       order: descending
   _inputs:
     title:
-      type: text
+      type: markdown
+      comment: >-
+        Markdown is supported for inline formatting — surround words with
+        underscores or asterisks to italicise them (e.g. *Editable Region*).
       options:
         required: true
         required_message: Tell the people what they get
         min_length: 5
         min_length_message: Tell people a bit more than that
+        # Restrict formatting to italic only — titles are one-line and
+        # shouldn't contain block-level or heavy inline formatting.
+        italic: true
+        bold: false
+        link: false
+        strike: false
+        underline: false
+        subscript: false
+        superscript: false
+        code: false
+        format: false
+        blockquote: false
+        bulletedlist: false
+        numberedlist: false
+        horizontalrule: false
+        image: false
+        embed: false
+        table: false
+        snippet: false
+        allow_resize: false
+        allow_custom_markup: false
       cascade: true
     $.date:
       type: datetime

--- a/_components/Card/Card.tsx
+++ b/_components/Card/Card.tsx
@@ -4,6 +4,9 @@ interface CardProps {
   comp: Comp;
   href?: string;
   title?: string;
+  // Pre-rendered HTML title (used when title needs inline markdown).
+  // Takes precedence over `title` when provided.
+  titleHtml?: string;
   description?: string;
   category?: string;
   icon?: string;
@@ -31,6 +34,7 @@ export default function Card({
   comp,
   href,
   title,
+  titleHtml,
   description,
   category,
   icon,
@@ -71,7 +75,7 @@ export default function Card({
       {label && <strong className="c-card__label">{label}</strong>}
 
       {/* Heading with optional icon */}
-      {title && (
+      {(title || titleHtml) && (
         <div className="c-card__heading">
           {icon && (
             <img
@@ -81,7 +85,14 @@ export default function Card({
               aria-hidden="true"
             />
           )}
-          <Heading className="c-card__title">{title}</Heading>
+          {titleHtml
+            ? (
+              <Heading
+                className="c-card__title"
+                dangerouslySetInnerHTML={{ __html: titleHtml }}
+              />
+            )
+            : <Heading className="c-card__title">{title}</Heading>}
         </div>
       )}
 

--- a/_includes/layouts/base.tsx
+++ b/_includes/layouts/base.tsx
@@ -57,10 +57,21 @@ export default function BaseLayout(props: Props, helpers: Helpers) {
     ga_verify,
   } = props;
 
-  const pageTitle_ = title ||
+  // Strip inline markdown emphasis (italic/bold) from titles so the browser
+  // tab, og:title, and twitter:title show clean text — the on-page heading
+  // still renders the markdown normally.
+  const stripInlineMarkdown = (s: string) =>
+    s
+      .replace(/\*\*([^*]+)\*\*/g, "$1") // **bold**
+      .replace(/__([^_]+)__/g, "$1") // __bold__
+      .replace(/\*([^*]+)\*/g, "$1") // *italic*
+      .replace(/_([^_]+)_/g, "$1"); // _italic_
+
+  const rawPageTitle = title ||
     (guide_title && details?.title
       ? `${details.title} — ${guide_title}`
       : details?.title) || "";
+  const pageTitle_ = stripInlineMarkdown(rawPageTitle);
   const pageDescription = description || details?.description ||
     meta?.description || "";
   const pageTitle = omit_trailing_title

--- a/_includes/layouts/changelog-cards.tsx
+++ b/_includes/layouts/changelog-cards.tsx
@@ -84,7 +84,10 @@ export default async function ChangelogCardsLayout(
                       <comp.Card.Card
                         key={ci}
                         href={changelog.url}
-                        title={changelog.page?.data?.title}
+                        titleHtml={helpers.md(
+                          String(changelog.page?.data?.title || ""),
+                          true,
+                        )}
                         date={changelog.page?.data?.date || ""}
                         description={renderedTextByMonth[mi]?.[ci] || ""}
                         variant="changelog"

--- a/_includes/layouts/changelog-list.tsx
+++ b/_includes/layouts/changelog-list.tsx
@@ -66,7 +66,15 @@ export default async function ChangelogListLayout(
                       ? "u-margin-top-0 changelog-entry__top-heading"
                       : ""}
                   >
-                    <a href={changelog.url}>{changelog.page?.data?.title}</a>
+                    <a
+                      href={changelog.url}
+                      dangerouslySetInnerHTML={{
+                        __html: helpers.md(
+                          String(changelog.page?.data?.title || ""),
+                          true,
+                        ),
+                      }}
+                    />
                   </h2>
                   <p className="changelog-entry__date">
                     <comp.RelativeDate date={changelog.page?.data?.date || ""} />

--- a/_includes/layouts/changelog.tsx
+++ b/_includes/layouts/changelog.tsx
@@ -46,9 +46,10 @@ export default function ChangelogLayout(props: Props, helpers: Helpers) {
             helpers={helpers}
           />
           <div>
-            <h1 className="l-heading changelog-entry__heading">
-              {title}
-            </h1>
+            <h1
+              className="l-heading changelog-entry__heading"
+              dangerouslySetInnerHTML={{ __html: helpers.md(title, true) }}
+            />
           </div>
           <p className="changelog-entry__date">
             <comp.RelativeDate date={date} />

--- a/changelogs/2026/04-02_improvements-to-repository-and-branch-selection.mdx
+++ b/changelogs/2026/04-02_improvements-to-repository-and-branch-selection.mdx
@@ -1,6 +1,6 @@
 ---
 _schema: default
-title: "Improvements to\_Repository\_and\_Branch\_selection"
+title: "Improvements to _Repository_ and _Branch_ selection"
 date: 2026-04-02T15:26:15+13:00
 ---
 This release improved performance and UI for *Repository* or *Branch* selection, and updated the *Getting Started with Editing* and *Getting Started: Setting up your Organization* guides.


### PR DESCRIPTION
It appears that Changelog titles should support italics but currently don't - looks like this one in particular has `_` in the title, and the content strongly suggests it is markdown italics around those particular words. 

https://cloudcannon.com/documentation/changelog/2026/04/02/improvements-to-repository-and-branch-selection/

However, the `_` is not being parsed as markdown and is being escaped instead, causing an extra long string in the title. That string is then wrapping 'anywhere' and creating the funky text you see on the production site.

This PR:

- parses inline markdown so titles can render italics
- parses changelog cards in the same way, so they render italics as well
- changed the CloudCannon input to `markdown` so italics can be added to titles
- strips the markdown syntax from the meta `<title>` field so underscores don't render in the page title

## Cloudvent for testing

https://crimson-creek.cloudvent.net/documentation/changelog/2026/04/02/improvements-to-repository-and-branch-selection/