### PR TITLE
Fix: inline code blocks wrapping

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -488,6 +488,36 @@ site.process([".html"], async function processInjectReusableContent(pages) {
 
 site.process([".html"], function processHTMLPages(pages) {
   for (const page of pages) {
+    // Bind inline `<code>` to adjacent parentheses so mobile line breaks
+    // don't strand a lone `(` on one line, the code on the next, and `)`
+    // below that. Insert U+2060 WORD JOINER (invisible, zero-width, forbids
+    // line break at its position) in the surrounding text nodes. Skip code
+    // inside <pre> blocks — those are display code and never wrap this way.
+    page.document?.querySelectorAll("code").forEach((codeEl) => {
+      const el = codeEl as unknown as HTMLElement & { parentElement?: unknown };
+      // Skip if inside a <pre> block
+      // deno-lint-ignore no-explicit-any
+      let anc: any = el;
+      while (anc) {
+        if (anc?.tagName === "PRE") return;
+        anc = anc.parentNode;
+      }
+      const prev = (codeEl as unknown as Node).previousSibling;
+      const next = (codeEl as unknown as Node).nextSibling;
+      if (prev && prev.nodeType === 3) {
+        const v = prev.nodeValue || "";
+        if (v.endsWith("(") && !v.endsWith("(⁠")) {
+          prev.nodeValue = v + "⁠";
+        }
+      }
+      if (next && next.nodeType === 3) {
+        const v = next.nodeValue || "";
+        if (v.startsWith(")") && !v.startsWith("⁠)")) {
+          next.nodeValue = "⁠" + v;
+        }
+      }
+    });
+
     const collisions: Record<string, boolean> = {};
 
     const fixIdCollisions = (slugPrefix: string): string => {

--- a/_includes/styles/elements.scss
+++ b/_includes/styles/elements.scss
@@ -53,7 +53,15 @@ dd code {
   border: 1px solid var(--inline-code-border);
   border-radius: 4px;
   white-space: pre-wrap;
-  display: inline-block;
+  display: inline;
+  // Allow long identifiers to wrap at any character when needed, so parens
+  // and text around the code aren't orphaned on narrow screens.
+  overflow-wrap: anywhere;
+  // With display: inline, the code can wrap across lines. Cloning
+  // decorations gives each line fragment its own rounded corners, padding
+  // and border — otherwise middle fragments would look flat.
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 a code {


### PR DESCRIPTION
Currently, code blocks that appear in parentheses tend to wrap oddly on mobile, usually splitting at the parentheses boundaries - i.e. one parenthesis on one line, and the code block on another (either top or bottom, see image).
<img width="431" height="379" alt="Screenshot 2026-08-02 at 9 30 53 PM" src="https://github.com/user-attachments/assets/aacaa009-a62a-4b4c-be26-20c4d2565678" />

This PR forces the code block to stay with the parentheses, and either (a) break the entire code block onto a new line if possible or (b) break on appropriate characters in the code block, e.g. `-` or `_` etc
<img width="441" height="370" alt="Screenshot 2026-08-02 at 9 31 17 PM" src="https://github.com/user-attachments/assets/2a1f4d8a-de8f-4ab6-bcff-ba5f112d54ec" />
