### PR TITLE
Fix: broken mermaid icons

### DIFF
--- a/_includes/layouts/base.tsx
+++ b/_includes/layouts/base.tsx
@@ -226,14 +226,18 @@ export default function BaseLayout(props: Props, helpers: Helpers) {
                   }
                 };
                 const PAN_STEP = 40;
+                // Wrap each icon URL with helpers.url() so the basePath
+                // (/documentation) is prepended. basePath() only rewrites
+                // src/href in HTML attributes, not JS strings inside script
+                // tags — without this, all these SVGs 404.
                 const ICON_URLS = ${JSON.stringify({
-                  "pan-up": helpers.icon("keyboard_arrow_up:outlined", "material"),
-                  "pan-down": helpers.icon("keyboard_arrow_down:outlined", "material"),
-                  "pan-left": helpers.icon("keyboard_arrow_left:outlined", "material"),
-                  "pan-right": helpers.icon("keyboard_arrow_right:outlined", "material"),
-                  "zoom-in": helpers.icon("zoom_in:outlined", "material"),
-                  "zoom-out": helpers.icon("zoom_out:outlined", "material"),
-                  "reset": helpers.icon("crop_free:outlined", "material"),
+                  "pan-up": helpers.url(helpers.icon("keyboard_arrow_up:outlined", "material")),
+                  "pan-down": helpers.url(helpers.icon("keyboard_arrow_down:outlined", "material")),
+                  "pan-left": helpers.url(helpers.icon("keyboard_arrow_left:outlined", "material")),
+                  "pan-right": helpers.url(helpers.icon("keyboard_arrow_right:outlined", "material")),
+                  "zoom-in": helpers.url(helpers.icon("zoom_in:outlined", "material")),
+                  "zoom-out": helpers.url(helpers.icon("zoom_out:outlined", "material")),
+                  "reset": helpers.url(helpers.icon("crop_free:outlined", "material")),
                 })};
                 const ACTIONS = [
                   ['pan-up',    'Pan up'],


### PR DESCRIPTION
On a page like this, there is a 'mermaid' chart thing: https://cloudcannon.com/documentation/user-articles/what-is-a-project/

It seems to be missing the icons to control the chart.

<img width="732" height="421" alt="Screenshot 2026-08-04 at 8 55 16 PM" src="https://github.com/user-attachments/assets/b074859a-3cbe-48a8-bdbe-3131dbd6d041" />

This PR fixes the URLs for the chart icons.

<img width="727" height="396" alt="Screenshot 2026-08-04 at 9 16 28 PM" src="https://github.com/user-attachments/assets/07ffa710-dd00-4afc-9cdd-0f5dd2be98d3" />

## Cloudvent for testing

https://silly-oak.cloudvent.net/documentation/user-articles/what-is-a-project/