### PR TITLE
Fix: light/dark icon flash

### DIFF
--- a/_components/Layout/Nav.tsx
+++ b/_components/Layout/Nav.tsx
@@ -27,18 +27,19 @@ function ThemeDropdown(
         }}
         x-on:click={`themeOpen = !themeOpen; if (themeOpen) $nextTick(() => $focus.within($refs.${dropdownRef}).first())`}
       >
-        <template x-if="effectiveTheme === 'dark'">
-          <img
-            src={helpers.icon("dark_mode:filled", "material")}
-            inline="true"
-          />
-        </template>
-        <template x-if="effectiveTheme === 'light'">
-          <img
-            src={helpers.icon("light_mode:filled", "material")}
-            inline="true"
-          />
-        </template>
+        {/* Both icons render — CSS shows the right one based on
+            data-pf-theme (set synchronously by the inline script in base.tsx
+            before Alpine loads, so there's no flash of the wrong icon). */}
+        <img
+          className="theme-toggle__icon theme-toggle__icon--dark"
+          src={helpers.icon("dark_mode:filled", "material")}
+          inline="true"
+        />
+        <img
+          className="theme-toggle__icon theme-toggle__icon--light"
+          src={helpers.icon("light_mode:filled", "material")}
+          inline="true"
+        />
       </button>
       <div
         id={id}

--- a/_includes/styles/nav.scss
+++ b/_includes/styles/nav.scss
@@ -232,6 +232,12 @@
         fill: var(--search-icon-fill);
         transition: fill 0.3s ease;
       }
+
+      // Hide both theme icons by default; the matching one is re-shown
+      // via top-level selectors below based on data-pf-theme.
+      .theme-toggle__icon {
+        display: none;
+      }
     }
   }
 
@@ -639,4 +645,15 @@
 
 footer .l-header__logo path {
 	fill: light-dark(var(--color-neptune), white);
+}
+
+// Show only the theme icon matching the current theme. data-pf-theme is
+// set synchronously by the inline script in base.tsx before Alpine loads,
+// so the correct icon is picked pre-render — no flash of the wrong icon.
+:root[data-pf-theme="dark"] .theme-toggle__icon--dark {
+  display: inline-block;
+}
+
+:root:not([data-pf-theme="dark"]) .theme-toggle__icon--light {
+  display: inline-block;
 }


### PR DESCRIPTION
A tiny PR - the light/dark symbol flickers briefly on page load/change.

This PR stops the flickering.

## Cloudvent for testing

https://prime-hero.cloudvent.net/documentation/