### PR TITLE
Fix: broken line in the guides

### DIFF
--- a/_includes/layouts/guide.tsx
+++ b/_includes/layouts/guide.tsx
@@ -141,8 +141,7 @@ export default function GuideLayout(props: Props, helpers: Helpers) {
                                 )
                                 : data.details?.order}
                             </span>
-                            {(data.details?.order || 0) <
-                                guideArticles.length &&
+                            {i < guideArticles.length - 1 &&
                               !guideArticles[i + 1]?.details
                                 ?.start_nav_group && (
                               <span


### PR DESCRIPTION
There is a broken line on this guide between step 13-14: https://cloudcannon.com/documentation/developer-guides/bookshop-astro-guide/configuring-live-editing/

<img width="303" height="349" alt="Screenshot 2026-08-04 at 10 16 50 PM" src="https://github.com/user-attachments/assets/b482696b-fb9b-4d8c-bc7d-33bf70844bb2" />

The line calculation is mistakenly comparing to order number and not array length - thus, the issue only showed on this guide because there's a weird numbering issue (missing 12 - but that's an issue that can be fixed in CloudCannon by fixing up the frontmatter; separate issue).

This PR fixes the broken line issue.

<img width="315" height="365" alt="Screenshot 2026-08-04 at 10 15 49 PM" src="https://github.com/user-attachments/assets/f7cca5e6-96dc-4507-a311-040e217a903c" />
