### PR TITLE
Fix: outdated steps and style guide issues

### DIFF
--- a/developer/articles/manually-configure-urls.mdx
+++ b/developer/articles/manually-configure-urls.mdx
@@ -29,7 +29,7 @@ However, this behavior may not be right for your <comp.GlossaryTerm term="/user/
   Before disabling CloudCannon's automatic URL detection, you must configure the `collections_config.[*].url` key for all output [Collections](/documentation/user-articles/what-is-a-collection/).
 </comp.Notice>
 
-You can set the output URL for a Collection in the *Data Editor* by opening your `cloudcannon.config.yml` file from your *File Browser*, or from the *Collection Browser* by turning on *Configuration Mode* and clicking the *Edit Advanced* button. Enter a value in the *URL* field for every output Collection on your Site. For more information, please read our documentation on [updating the output URL for a Collection](/documentation/developer-articles/update-the-output-url-for-a-collection/).
+You can set the output URL for a <comp.GlossaryTerm term="/user/glossary/c/collection.yml">Collection</comp.GlossaryTerm> in the *Data Editor* by opening your `cloudcannon.config.yml` file from your <comp.GlossaryTerm term="/user/glossary/f/file-browser.yml">File Browser</comp.GlossaryTerm>, or from the <comp.GlossaryTerm term="/user/glossary/c/collection-browser.yml">Collection Browser</comp.GlossaryTerm> by turning on <comp.GlossaryTerm term="/user/glossary/c/configuration-mode.yml">Configuration Mode</comp.GlossaryTerm> and clicking the *Edit Advanced* button. Enter a value in the *URL* field for every output *Collection* on your Site. For more information, please read our documentation on [updating the output URL for a Collection](/documentation/developer-articles/update-the-output-url-for-a-collection/).
 
 To disable automatic URL detection:
 

--- a/developer/articles/manually-configure-urls.mdx
+++ b/developer/articles/manually-configure-urls.mdx
@@ -21,7 +21,7 @@ details:
 author_notes:
   docshots: Added!
 ---
-By default, CloudCannon automatically detects the output URLs for your files and assigns them at [build](/documentation/developer-articles/what-is-a-site-build/) time. This is useful because you do not need to assign an output URL to each of your files yourself.
+By default, CloudCannon automatically detects the output URLs for your files and assigns them at [build](/documentation/developer-articles/what-is-a-site-build/) time. This is useful because you do not need to assign an output URL to each file yourself.
 
 However, this behavior may not be right for your Site if it has a large number of files or a custom Site configuration. On these Sites, automatic URL detection can slow down your build time. To avoid this, you can disable automatic URL detection and configure your output URLs manually.
 

--- a/developer/articles/manually-configure-urls.mdx
+++ b/developer/articles/manually-configure-urls.mdx
@@ -33,7 +33,7 @@ You can set the output URL for a <comp.GlossaryTerm term="/user/glossary/c/colle
 
 To disable automatic URL detection:
 
-1. Navigate to the *Builds* > *Configuration* page under *Site Settings*.
+1. Navigate to the *Configuration* page under *Site Settings*.
 2. Check the *Manually Configure URLs* checkbox under *Build system options*.
 3. Click the *Update Configuration and Build* button.
 

--- a/developer/articles/manually-configure-urls.mdx
+++ b/developer/articles/manually-configure-urls.mdx
@@ -23,7 +23,7 @@ author_notes:
 ---
 By default, CloudCannon automatically detects the output URLs for your files and assigns them at [build](/documentation/developer-articles/what-is-a-site-build/) time. This is useful because you do not need to assign an output URL to each file yourself.
 
-However, this behavior may not be right for your Site if it has a large number of files or a custom Site configuration. On these Sites, automatic URL detection can slow down your build time. To avoid this, you can disable automatic URL detection and configure your output URLs manually.
+However, this behavior may not be right for your <comp.GlossaryTerm term="/user/glossary/s/site.yml">Site</comp.GlossaryTerm> if it has a large number of files or a custom *Site* configuration. On these *Sites*, automatic URL detection can slow down your build time. To avoid this, you can disable automatic URL detection and configure your output URLs manually.
 
 <comp.Notice info_type="important">
   Before disabling CloudCannon's automatic URL detection, you must configure the `collections_config.[*].url` key for all output [Collections](/documentation/user-articles/what-is-a-collection/).

--- a/developer/articles/manually-configure-urls.mdx
+++ b/developer/articles/manually-configure-urls.mdx
@@ -21,29 +21,27 @@ details:
 author_notes:
   docshots: Added!
 ---
-By default, CloudCannon automatically detect the output URLs for your files and assigns them at [build](/documentation/developer-articles/what-is-a-site-build/) time. This is useful as you do not need to manually assign output URLs to each of your files.
+By default, CloudCannon automatically detects the output URLs for your files and assigns them at [build](/documentation/developer-articles/what-is-a-site-build/) time. This is useful because you do not need to assign an output URL to each of your files yourself.
 
-However, this behavior may not be right for your Site if it has a larger number of files or custom Site configuration. For these Sites, CloudCannon's URLs assigning behavior may slow down your build time. For these Sites, you can disable automatic output URLs in CloudCannon and manually configure your output URLs.
+However, this behavior may not be right for your Site if it has a large number of files or a custom Site configuration. On these Sites, automatic URL detection can slow down your build time. To avoid this, you can disable automatic URL detection and configure your output URLs manually.
 
 <comp.Notice info_type="important">
-  Before disabling CloudCannon's automatic URL detection, you must configure the `collections\_config.\[\*\].url` key for all output [Collections](/documentation/user-articles/what-is-a-collection/).
+  Before disabling CloudCannon's automatic URL detection, you must configure the `collections_config.[*].url` key for all output [Collections](/documentation/user-articles/what-is-a-collection/).
 </comp.Notice>
 
-To manually configure your URLs:
+You can set the output URL for a Collection in the *Data Editor* by opening your `cloudcannon.config.yml` file from your *File Browser*, or from the *Collection Browser* by turning on *Configuration Mode* and clicking the *Edit Advanced* button. Enter a value in the *URL* field for every output Collection on your Site. For more information, please read our documentation on [updating the output URL for a Collection](/documentation/developer-articles/update-the-output-url-for-a-collection/).
 
-1. Navigate to the *editing* page under *Site Settings*.
-2. Click on the *Edit your configuration file* button to open your CloudCannon configuration file.
-3. Navigate to the *Collections* array under the *Collections and Paths* section.
-4. Click on each output Collections in the *Collections* array and ensure you have configured the *URL* key for each Collection.
-5. When you are happy with your manually configured URLs for each output Collection, navigate to the *Build Configuration* page under *Site Settings*.
-6. Check the *Manually Configure URLs* flag under *Build system options*.
-7. Click the *Update Configuration and Build* button.
+To disable automatic URL detection:
+
+1. Navigate to the *Builds* > *Configuration* page under *Site Settings*.
+2. Check the *Manually Configure URLs* checkbox under *Build system options*.
+3. Click the *Update Configuration and Build* button.
 
 CloudCannon will immediately build your Site using the manually configured URLs.
 
 <comp.DocShot docshot_key="CloudCannon-Documentation-Site-Settings-Build-Configuration-Manually-Configure-URLs" alt="The Build Configuration page scrolled to the Build system options section, showing the Manually Configure URLs checkbox." title="The Manually Configure URLs option" type="screenshot" />
 
-If you would prefer to configure the output URLs for your Collections in the Source Editor or your local development environment, you can achieve the same configuration with the following code:
+If you would prefer to configure the output URLs for your Collections in the *Source Editor* or your local development environment, you can achieve the same configuration with the following code:
 
 <comp.MultiCodeBlock language="YAML" translate_into={["json"]} source="cloudcannon.config.yml">
 ``````````

--- a/developer/articles/manually-configure-urls.mdx
+++ b/developer/articles/manually-configure-urls.mdx
@@ -41,7 +41,7 @@ CloudCannon will immediately build your Site using the manually configured URLs.
 
 <comp.DocShot docshot_key="CloudCannon-Documentation-Site-Settings-Build-Configuration-Manually-Configure-URLs" alt="The Build Configuration page scrolled to the Build system options section, showing the Manually Configure URLs checkbox." title="The Manually Configure URLs option" type="screenshot" />
 
-If you would prefer to configure the output URLs for your Collections in the *Source Editor* or your local development environment, you can achieve the same configuration with the following code:
+If you would prefer to configure the output URLs for your *Collections* in the *Source Editor* or your local development environment, you can achieve the same configuration with the following code:
 
 <comp.MultiCodeBlock language="YAML" translate_into={["json"]} source="cloudcannon.config.yml">
 ``````````


### PR DESCRIPTION
The steps for configuring Collection URLs pointed at a UI route that no longer exists.

- Replaced steps 1-4 with a summary of the two routes, linking to the output URL page for further instruction
- Updated the build settings path to *Builds* > *Configuration*
- Renamed the list lead-in to "To disable automatic URL detection" so it describes what the remaining three steps do
- Fixed escaped code in the notice, which rendered literally as `collections\_config.\[\*\].url`
- Fixed page to match style guide