### PR TITLE
Added a routing entry for an outdated url found in the app

### DIFF
--- a/.cloudcannon/routing.json
+++ b/.cloudcannon/routing.json
@@ -82,6 +82,11 @@
       "status": 301
     },
     {
+      "from": "/documentation/articles/configure-pull-request-templates/",
+      "to": "/documentation/developer-articles/configure-a-pull-request-template/",
+      "status": 301
+    },
+    {
       "from": "/documentation/guides/astro-starter-guide/syncing/",
       "to": "/documentation/guides/getting-started-with-cloudcannon/create-a-site/",
       "status": 301


### PR DESCRIPTION
In the app, there is a doc link to https://cloudcannon.com/documentation/articles/configure-pull-request-templates/
<img width="766" height="613" alt="Screenshot 2026-08-25 at 2 50 22 PM" src="https://github.com/user-attachments/assets/96788004-f9a2-4205-9f07-08cad8c7a230" />

But there was no routing entry for this...

## Cloudvent for testing

https://merciful-crayon.cloudvent.net/documentation/