### PR TITLE
Fix: heading line-height

### DIFF
--- a/_includes/styles/shortcodes.scss
+++ b/_includes/styles/shortcodes.scss
@@ -246,7 +246,7 @@
   }
 
   &__description,
-  &__description > div {
+  &__description > div:not(.c-notice) {
     display: block;
 
     > :first-child {

--- a/_includes/styles/shortcodes.scss
+++ b/_includes/styles/shortcodes.scss
@@ -258,6 +258,14 @@
     }
   }
 
+  // Notices inside a description inherit the smaller font-size and their
+  // text's cap-height ends up higher relative to the container's top edge
+  // than in body-level notices. Trim the icon's padding-top so it lines up
+  // with the notice's first line of text again.
+  &__description .c-notice__icon {
+    padding-top: 1px;
+  }
+
   // Workaround for dangerouslySetInnerHTML forcing inside div
   &__description > div:not(:last-child) {
     margin-bottom: var(--gap-half);

--- a/_includes/styles/typography.scss
+++ b/_includes/styles/typography.scss
@@ -1,5 +1,8 @@
 h1 {
   font-size: var(--font-size-xx-large);
+  // Tighter than the body 1.6 — at 48px, an inherited 1.6 leaves a huge
+  // gap between wrapped lines and the heading stops reading as one unit.
+  line-height: 1.15;
 
   @media (max-width: 400px) {
     font-size: calc(var(--font-size-xx-large) * 0.875);
@@ -16,6 +19,13 @@ h4 {
     margin-top: 0.6em;
   }
 }
+
+// Line-height loosens as heading size decreases, ramping toward the body 1.6
+// so smaller headings get the extra breathing room shorter text needs while
+// large display type stays tight enough to read as a single unit.
+h2 { line-height: 1.3; }
+h3 { line-height: 1.4; }
+h4 { line-height: 1.5; }
 
 h2 + h3 {
   margin-top: 0.6em;


### PR DESCRIPTION
Fixed heading line-heights - not explicitly set, so inheriting body's `1.6`.

Now as heading size increases, line-height decreases:

h1 1.15
h2 1.3
h3 1.4
h4 1.5
body 1.6

Bonus: also, at some stage the icons in `c-notice` *inside* codeblocks got `display:block` applied. 