### PR TITLE
Fix/glossary tooltips

### DIFF
--- a/_components/GlossaryTerm.tsx
+++ b/_components/GlossaryTerm.tsx
@@ -16,63 +16,76 @@ export default function GlossaryTerm(
   return (
     <span
       x-data="{
-        tooltipopen: false,
-        closeTimeout: null,
-        openTimeout: null,
-
-        scheduleOpen: function () {
+        aName: '--gloss-' + Math.random().toString(36).slice(2, 10),
+        show: false,
+        openT: null,
+        closeT: null,
+        open() {
+          this.cancelClose();
+          clearTimeout(this.openT);
+          this.openT = setTimeout(() => { this.show = true; }, 100);
+        },
+        close() {
           this.cancelOpen();
-          this.openTimeout = setTimeout(() => {
-            this.tooltipopen = true;
-          }, 100);
-          $nextTick(() => this.update());
+          clearTimeout(this.closeT);
+          this.closeT = setTimeout(() => { this.show = false; }, 100);
         },
-
-        cancelOpen: function () {
-          if (this.openTimeout) {
-            clearTimeout(this.openTimeout);
-            this.openTimeout = null;
-          }
-        },
-
-        scheduleClose: function () {
+        closeNow() {
           this.cancelOpen();
           this.cancelClose();
-          this.closeTimeout = setTimeout(() => {
-            this.tooltipopen = false;
-          }, 100)
+          this.show = false;
         },
-
-        cancelClose: function () {
-          if (this.closeTimeout) {
-            clearTimeout(this.closeTimeout);
-            this.closeTimeout = null;
-          }
+        cancelOpen() { clearTimeout(this.openT); this.openT = null; },
+        cancelClose() { clearTimeout(this.closeT); this.closeT = null; },
+        onDocClick(e) {
+          if (!this.show) return;
+          if (this.$el.contains(e.target)) return;
+          if (this.$refs.tooltip && this.$refs.tooltip.contains(e.target)) return;
+          this.closeNow();
         },
-
-        update: function () {
-          const rect = $el.getBoundingClientRect();
-          $refs.tooltip.style.top =
-            rect.bottom + window.scrollY + 6 + 'px';
-          $refs.tooltip.style.left =
-            rect.left + window.scrollX + 'px';
-        }
       }"
-      x-on:mouseenter="scheduleOpen"
-      x-on:mouseleave="scheduleClose"
+      x-bind:style="'anchor-name: ' + aName"
+      x-on:mouseenter="open"
+      x-on:mouseleave="close"
+      {...{
+        "x-on:keydown.escape.window": "closeNow",
+        "x-on:click.window": "onDocClick",
+      }}
       class="glossary-term-highlight"
     >
       {children}
 
+      {/* Teleport into <body>: a <div> as a direct child of an inline
+          <span> would be auto-corrected out by the HTML parser (span is
+          phrasing-only), severing it from Alpine's x-data scope and
+          losing the aName binding. */}
       <template x-teleport="body">
         <div
-          x-show="tooltipopen"
+          x-show="show"
           x-transition
           x-ref="tooltip"
-          class="term-definition"
+          x-bind:style="'position-anchor: ' + aName"
           x-on:mouseenter="cancelClose"
-          x-on:mouseleave="scheduleClose"
+          x-on:mouseleave="close"
+          class="term-definition"
+          role="tooltip"
         >
+          <button
+            type="button"
+            class="term-definition__close"
+            aria-label="Close"
+            x-on:click="closeNow"
+          >
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+            >
+              <path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+            </svg>
+          </button>
           <div dangerouslySetInnerHTML={{ __html: content }} />
         </div>
       </template>

--- a/_components/GlossaryTerm.tsx
+++ b/_components/GlossaryTerm.tsx
@@ -31,9 +31,12 @@ export default function GlossaryTerm(
           this.closeT = setTimeout(() => { this.show = false; }, 100);
         },
         closeNow() {
+          const fromInside = this.$refs.tooltip &&
+            this.$refs.tooltip.contains(document.activeElement);
           this.cancelOpen();
           this.cancelClose();
           this.show = false;
+          if (fromInside) { this.$nextTick(() => this.$el.focus()); }
         },
         cancelOpen() { clearTimeout(this.openT); this.openT = null; },
         cancelClose() { clearTimeout(this.closeT); this.closeT = null; },
@@ -45,8 +48,12 @@ export default function GlossaryTerm(
         },
       }"
       x-bind:style="'anchor-name: ' + aName"
+      x-bind:aria-describedby="aName.slice(2)"
       x-on:mouseenter="open"
       x-on:mouseleave="close"
+      x-on:focus="open"
+      x-on:blur="close"
+      tabindex="0"
       {...{
         "x-on:keydown.escape.window": "closeNow",
         "x-on:click.window": "onDocClick",
@@ -64,9 +71,12 @@ export default function GlossaryTerm(
           x-show="show"
           x-transition
           x-ref="tooltip"
+          x-bind:id="aName.slice(2)"
           x-bind:style="'position-anchor: ' + aName"
           x-on:mouseenter="cancelClose"
           x-on:mouseleave="close"
+          x-on:focusin="cancelClose"
+          x-on:focusout="close"
           class="term-definition"
           role="tooltip"
         >

--- a/_includes/styles/shortcodes.scss
+++ b/_includes/styles/shortcodes.scss
@@ -411,18 +411,29 @@
   inset: unset;
   width: min(400px, calc(100vw - 32px));
   z-index: 15;
-  background: var(--color-purple-200);
-  padding: 12px 16px 16px;
-  color: var(--color-carbon);
-  border-radius: 8px;
+  padding: 14px 18px 16px;
+  border-radius: 6px;
+  border: none;
   line-height: var(--line-height-small);
   font-size: var(--font-size-small);
-  border: 1px solid var(--color-purple-600);
+  // Adaptive surface — the familiar light-purple pill in light mode so it
+  // stands out from the white page, and a lifted muted purple in dark mode
+  // that sits clearly above the ~#2c2c2c page background instead of
+  // vanishing into it. Text follows --text so it inverts with the theme.
+  background: light-dark(var(--color-purple-200), #3d2f45);
+  color: var(--text);
+  box-shadow:
+    0 1px 2px light-dark(rgba(40, 12, 60, 0.08), rgba(0, 0, 0, 0.45)),
+    0 12px 32px light-dark(rgba(120, 40, 150, 0.12), rgba(0, 0, 0, 0.55));
 
   & .eyebrow {
-    font-size: var(--font-size-x-small);
+    display: inline-block;
+    font-size: var(--font-size-xx-small);
+    font-weight: var(--font-weight-bold);
     text-transform: uppercase;
-    color: var(--color-purple);
+    letter-spacing: 0.5px;
+    color: light-dark(var(--color-purple), var(--color-purple-400));
+    margin-bottom: 4px;
   }
 
   & h3 {
@@ -431,6 +442,7 @@
     // underneath it.
     padding-right: 32px;
     font-style: italic;
+    color: var(--text);
   }
 
   & p:last-of-type {
@@ -456,15 +468,14 @@
     background: none;
     border: none;
     border-radius: 4px;
-    color: var(--color-purple);
+    color: light-dark(var(--color-purple), var(--color-purple-400));
     cursor: pointer;
 
     & svg { fill: currentColor; }
 
     &:hover,
     &:focus-visible {
-      background: var(--color-purple-400);
-      color: var(--color-cloud);
+      background: light-dark(var(--color-purple-200), rgba(233, 154, 239, 0.18));
     }
 
     &:focus-visible {

--- a/_includes/styles/shortcodes.scss
+++ b/_includes/styles/shortcodes.scss
@@ -399,14 +399,22 @@
 }
 
 .term-definition {
-  position: absolute;
-  z-index: 2000;
-  width: 400px;
+  // Anchor positioning ties the tooltip to the term it describes: it stays
+  // pinned as the page scrolls, and position-try-fallbacks flips the
+  // placement when the primary side would overflow the viewport.
+  // z-index is deliberately below the sticky nav header (z-index: 20 in
+  // layout.scss) so the nav always stays on top when scrolling.
+  position: fixed;
+  position-area: bottom span-right;
+  position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
+  margin: 6px 0 0;
+  inset: unset;
+  width: min(400px, calc(100vw - 32px));
+  z-index: 15;
   background: var(--color-purple-200);
   padding: 12px 16px 16px;
   color: var(--color-carbon);
   border-radius: 8px;
-  left: 0;
   line-height: var(--line-height-small);
   font-size: var(--font-size-small);
   border: 1px solid var(--color-purple-600);
@@ -419,10 +427,49 @@
 
   & h3 {
     margin-top: 0 !important;
+    // Leave room for the close button so a long term name doesn't run
+    // underneath it.
+    padding-right: 32px;
     font-style: italic;
   }
 
   & p:last-of-type {
     margin-bottom: 0;
+  }
+
+  &__close {
+    // Sits on the eyebrow line — top: 8 + button center at 8 + 16 = 24px
+    // aligns with the eyebrow text baseline for a tidy visual anchor.
+    // Interactive size is 32×32 for pointer legibility, and box-sizing plus
+    // a padding-driven hit area gives a 40×40 tap target without inflating
+    // the visible pill.
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: content-box;
+    width: 24px;
+    height: 24px;
+    padding: 4px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    color: var(--color-purple);
+    cursor: pointer;
+
+    & svg { fill: currentColor; }
+
+    &:hover,
+    &:focus-visible {
+      background: var(--color-purple-400);
+      color: var(--color-cloud);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-purple-600);
+      outline-offset: 1px;
+    }
   }
 }


### PR DESCRIPTION
Redesigned glossary tooltips:

- better positioning, especially on mobile
- darkmode colours for tooltip
- a11y improvements with `aria-describedby` and `tabindex`

## Cloudvent for testing

https://still-beech.cloudvent.net/documentation/developer-articles/